### PR TITLE
Support for N dimensions in EntropyBottleneck

### DIFF
--- a/tests/test_entropy_models.py
+++ b/tests/test_entropy_models.py
@@ -158,7 +158,7 @@ class TestEntropyBottleneck:
         assert ((y - x) >= -0.5).all()
         assert (y != torch.round(x)).any()
 
-    def test_forward_inference(self):
+    def test_forward_inference_2D(self):
         entropy_bottleneck = EntropyBottleneck(128)
         entropy_bottleneck.eval()
         x = torch.rand(1, 128, 32, 32)
@@ -168,6 +168,20 @@ class TestEntropyBottleneck:
         assert y_likelihoods.shape == x.shape
 
         assert (y == torch.round(x)).all()
+
+    def test_forward_inference_ND(self):
+        entropy_bottleneck = EntropyBottleneck(128)
+        entropy_bottleneck.eval()
+
+        # Test from 1 to 5 dimensions
+        for i in range(1, 6):
+            x = torch.rand(1, 128, *([4] * i))
+            y, y_likelihoods = entropy_bottleneck(x)
+
+            assert y.shape == x.shape
+            assert y_likelihoods.shape == x.shape
+
+            assert (y == torch.round(x)).all()
 
     def test_loss(self):
         entropy_bottleneck = EntropyBottleneck(128)

--- a/tests/test_entropy_models.py
+++ b/tests/test_entropy_models.py
@@ -158,6 +158,17 @@ class TestEntropyBottleneck:
         assert ((y - x) >= -0.5).all()
         assert (y != torch.round(x)).any()
 
+    def test_forward_inference_0D(self):
+        entropy_bottleneck = EntropyBottleneck(128)
+        entropy_bottleneck.eval()
+        x = torch.rand(1, 128)
+        y, y_likelihoods = entropy_bottleneck(x)
+
+        assert y.shape == x.shape
+        assert y_likelihoods.shape == x.shape
+
+        assert (y == torch.round(x)).all()
+
     def test_forward_inference_2D(self):
         entropy_bottleneck = EntropyBottleneck(128)
         entropy_bottleneck.eval()


### PR DESCRIPTION
Hello,

Thanks for this great library!

I added support for N dimensional tensors in the EntropyBottleneck with associated unit tests.
It doesn't break the existing interface (support for 2D images) and adds support for higher (3 and above) and lower dimensions (0, 1).

I have added relevant unit tests and they pass successfully.

Please let me know if this is of interest to you.

Best,

Maurice