### PR TITLE
Typos and recursive dataset structure in utils.bench

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# PyCharm
+.idea/

--- a/compressai/utils/bench/__main__.py
+++ b/compressai/utils/bench/__main__.py
@@ -50,9 +50,13 @@ def func(codec, i, *args):
 
 
 def collect(codec: Codec, dataset: str, qualities: List[int], num_jobs: int = 1):
+    if not os.path.isdir(dataset):
+        raise OSError(f"No such directory: {dataset}")
+
     filepaths = [
-        os.path.join(dataset, f)
-        for f in os.listdir(dataset)
+        os.path.join(dirpath, f)
+        for dirpath, dirnames, filenames in os.walk(dataset)
+        for f in filenames
         if os.path.splitext(f)[-1].lower() in IMG_EXTENSIONS
     ]
 

--- a/compressai/utils/bench/codecs.py
+++ b/compressai/utils/bench/codecs.py
@@ -139,7 +139,7 @@ class Codec:
 
 
 class PillowCodec(Codec):
-    """Abastract codec based on Pillow bindings."""
+    """Abstract codec based on Pillow bindings."""
 
     fmt = None
 
@@ -204,9 +204,13 @@ class WebP(PillowCodec):
 
 
 class BinaryCodec(Codec):
-    """Call a external binary."""
+    """Call an external binary."""
 
     fmt = None
+
+    @property
+    def name(self):
+        raise NotImplementedError()
 
     def _run(self, img, quality, return_rec=False, return_metrics=True):
         fd0, png_filepath = mkstemp(suffix=".png")


### PR DESCRIPTION
Directory structures like:
```
root
  - train
    - img01
    - ...
  - val
    - img01
    - ...
```
are currently not supported by the `utils.bench` module. I added an `os.walk()` to recursively build a file list.

Misc changes:
- Typos
- Added a missing abstract method implementation in `BinaryCodec`
- Added `.idea` to `.gitignore` for PyCharm users