### PR TITLE
FIX: Arg parser of codec.py was using the wrong command name

### DIFF
--- a/examples/codec.py
+++ b/examples/codec.py
@@ -335,9 +335,9 @@ def main(argv):
     args = parse_args(argv[1:2])
     argv = argv[2:]
     torch.set_num_threads(1)  # just to be sure
-    if args.command == "img_encode":
+    if args.command == "encode":
         encode(argv)
-    elif args.command == "img_decode":
+    elif args.command == "decode":
         decode(argv)
 
 


### PR DESCRIPTION
The choices were encode and decode, but the only arguments that were
checked for were img_encode and img_decode. This resulted in one not
being able to use the codec example.