### PR TITLE
ci: Remove pip caching for static-analysis

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -14,15 +14,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Cache pip
-      uses: actions/cache@v2
-      if: ${{ !env.ACT }}
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-          ${{ runner.os }}-
     - name: Install Python dependencies
       run: pip install -e .[dev]
     - name: Run static analysis checks


### PR DESCRIPTION
Remove the pip cache from static analysis stage. This allows installation
of the latest version of tooling for the stage and avoids discrepancies
with stale requirements.txt.