### PR TITLE
fix: examples/train*.py argparse types

### DIFF
--- a/examples/train.py
+++ b/examples/train.py
@@ -206,6 +206,7 @@ def parse_args(argv):
     )
     parser.add_argument(
         "--aux-learning-rate",
+        type=float,
         default=1e-3,
         help="Auxiliary loss learning rate (default: %(default)s)",
     )
@@ -220,9 +221,7 @@ def parse_args(argv):
     parser.add_argument(
         "--save", action="store_true", default=True, help="Save model to disk"
     )
-    parser.add_argument(
-        "--seed", type=float, help="Set random seed for reproducibility"
-    )
+    parser.add_argument("--seed", type=int, help="Set random seed for reproducibility")
     parser.add_argument(
         "--clip_max_norm",
         default=1.0,

--- a/examples/train_video.py
+++ b/examples/train_video.py
@@ -346,6 +346,7 @@ def parse_args(argv):
     )
     parser.add_argument(
         "--aux-learning-rate",
+        type=float,
         default=1e-3,
         help="Auxiliary loss learning rate (default: %(default)s)",
     )
@@ -360,9 +361,7 @@ def parse_args(argv):
     parser.add_argument(
         "--save", action="store_true", default=True, help="Save model to disk"
     )
-    parser.add_argument(
-        "--seed", type=float, help="Set random seed for reproducibility"
-    )
+    parser.add_argument("--seed", type=int, help="Set random seed for reproducibility")
     parser.add_argument(
         "--clip_max_norm",
         default=1.0,


### PR DESCRIPTION
To avoid errors:

- `--seed` should be `int`
- `--aux-learning-rate` should be `float`