### PR TITLE
feat: LatentCodec abstraction for easier experimentation and composition

### DIFF
--- a/compressai/latent_codecs/__init__.py
+++ b/compressai/latent_codecs/__init__.py
@@ -27,83 +27,21 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from compressai import (
-    datasets,
-    entropy_models,
-    latent_codecs,
-    layers,
-    losses,
-    models,
-    ops,
-    optimizers,
-    registry,
-    transforms,
-    typing,
-    zoo,
-)
-
-try:
-    from .version import __version__
-except ImportError:
-    pass
-
-_entropy_coder = "ans"
-_available_entropy_coders = [_entropy_coder]
-
-try:
-    import range_coder
-
-    _available_entropy_coders.append("rangecoder")
-except ImportError:
-    pass
-
-
-def set_entropy_coder(entropy_coder):
-    """
-    Specifies the default entropy coder used to encode the bit-streams.
-
-    Use :mod:`available_entropy_coders` to list the possible values.
-
-    Args:
-        entropy_coder (string): Name of the entropy coder
-    """
-    global _entropy_coder
-    if entropy_coder not in _available_entropy_coders:
-        raise ValueError(
-            f'Invalid entropy coder "{entropy_coder}", choose from'
-            f'({", ".join(_available_entropy_coders)}).'
-        )
-    _entropy_coder = entropy_coder
-
-
-def get_entropy_coder():
-    """
-    Return the name of the default entropy coder used to encode the bit-streams.
-    """
-    return _entropy_coder
-
-
-def available_entropy_coders():
-    """
-    Return the list of available entropy coders.
-    """
-    return _available_entropy_coders
-
+from .base import LatentCodec
+from .entropy_bottleneck import EntropyBottleneckLatentCodec
+from .gain import GainHyperLatentCodec, GainHyperpriorLatentCodec
+from .gaussian_conditional import GaussianConditionalLatentCodec
+from .hyper import HyperLatentCodec
+from .hyperprior import HyperpriorLatentCodec
+from .rasterscan import RasterScanLatentCodec
 
 __all__ = [
-    "datasets",
-    "entropy_models",
-    "latent_codecs",
-    "layers",
-    "losses",
-    "models",
-    "ops",
-    "optimizers",
-    "registry",
-    "transforms",
-    "typing",
-    "zoo",
-    "available_entropy_coders",
-    "get_entropy_coder",
-    "set_entropy_coder",
+    "LatentCodec",
+    "EntropyBottleneckLatentCodec",
+    "GainHyperLatentCodec",
+    "GainHyperpriorLatentCodec",
+    "GaussianConditionalLatentCodec",
+    "HyperLatentCodec",
+    "HyperpriorLatentCodec",
+    "RasterScanLatentCodec",
 ]

--- a/compressai/latent_codecs/entropy_bottleneck.py
+++ b/compressai/latent_codecs/entropy_bottleneck.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2021-2022, InterDigital Communications, Inc
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted (subject to the limitations in the disclaimer
+# below) provided that the following conditions are met:
+
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of InterDigital Communications, Inc nor the names of its
+#   contributors may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+
+# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+# THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+# NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from typing import Any, Dict, List, Tuple
+
+from torch import Tensor
+
+from compressai.entropy_models import EntropyBottleneck
+from compressai.registry import register_module
+
+from .base import LatentCodec
+
+__all__ = [
+    "EntropyBottleneckLatentCodec",
+]
+
+
+@register_module("EntropyBottleneckLatentCodec")
+class EntropyBottleneckLatentCodec(LatentCodec):
+    """Entropy bottleneck codec.
+
+    Factorized prior "entropy bottleneck" introduced in
+    `"Variational Image Compression with a Scale Hyperprior"
+    <https://arxiv.org/abs/1802.01436>`_,
+    by J. Balle, D. Minnen, S. Singh, S.J. Hwang, and N. Johnston,
+    International Conference on Learning Representations (ICLR), 2018.
+
+    .. code-block:: none
+
+               ┌───┐ y_hat
+        y ──►──┤ Q ├───►───····───►─── y_hat
+               └───┘        EB
+
+    """
+
+    entropy_bottleneck: EntropyBottleneck
+
+    def __init__(self, N: int, **kwargs):
+        super().__init__()
+        self._kwargs = kwargs
+        self.N = N
+        self._setdefault("entropy_bottleneck", lambda: EntropyBottleneck(N))
+
+    def forward(self, y: Tensor) -> Dict[str, Any]:
+        y_hat, y_likelihoods = self.entropy_bottleneck(y)
+        return {"likelihoods": {"y": y_likelihoods}, "y_hat": y_hat}
+
+    def compress(self, y: Tensor) -> Dict[str, Any]:
+        shape = y.size()[-2:]
+        y_strings = self.entropy_bottleneck.compress(y)
+        y_hat = self.entropy_bottleneck.decompress(y_strings, shape)
+        return {"strings": [y_strings], "shape": shape, "y_hat": y_hat}
+
+    def decompress(
+        self, strings: List[List[bytes]], shape: Tuple[int, int]
+    ) -> Dict[str, Any]:
+        (y_strings,) = strings
+        y_hat = self.entropy_bottleneck.decompress(y_strings, shape)
+        return {"y_hat": y_hat}

--- a/compressai/latent_codecs/gain/__init__.py
+++ b/compressai/latent_codecs/gain/__init__.py
@@ -27,83 +27,10 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from compressai import (
-    datasets,
-    entropy_models,
-    latent_codecs,
-    layers,
-    losses,
-    models,
-    ops,
-    optimizers,
-    registry,
-    transforms,
-    typing,
-    zoo,
-)
-
-try:
-    from .version import __version__
-except ImportError:
-    pass
-
-_entropy_coder = "ans"
-_available_entropy_coders = [_entropy_coder]
-
-try:
-    import range_coder
-
-    _available_entropy_coders.append("rangecoder")
-except ImportError:
-    pass
-
-
-def set_entropy_coder(entropy_coder):
-    """
-    Specifies the default entropy coder used to encode the bit-streams.
-
-    Use :mod:`available_entropy_coders` to list the possible values.
-
-    Args:
-        entropy_coder (string): Name of the entropy coder
-    """
-    global _entropy_coder
-    if entropy_coder not in _available_entropy_coders:
-        raise ValueError(
-            f'Invalid entropy coder "{entropy_coder}", choose from'
-            f'({", ".join(_available_entropy_coders)}).'
-        )
-    _entropy_coder = entropy_coder
-
-
-def get_entropy_coder():
-    """
-    Return the name of the default entropy coder used to encode the bit-streams.
-    """
-    return _entropy_coder
-
-
-def available_entropy_coders():
-    """
-    Return the list of available entropy coders.
-    """
-    return _available_entropy_coders
-
+from .hyper import GainHyperLatentCodec
+from .hyperprior import GainHyperpriorLatentCodec
 
 __all__ = [
-    "datasets",
-    "entropy_models",
-    "latent_codecs",
-    "layers",
-    "losses",
-    "models",
-    "ops",
-    "optimizers",
-    "registry",
-    "transforms",
-    "typing",
-    "zoo",
-    "available_entropy_coders",
-    "get_entropy_coder",
-    "set_entropy_coder",
+    "GainHyperLatentCodec",
+    "GainHyperpriorLatentCodec",
 ]

--- a/compressai/latent_codecs/gain/hyper.py
+++ b/compressai/latent_codecs/gain/hyper.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2021-2022, InterDigital Communications, Inc
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted (subject to the limitations in the disclaimer
+# below) provided that the following conditions are met:
+
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of InterDigital Communications, Inc nor the names of its
+#   contributors may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+
+# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+# THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+# NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from typing import Any, Dict, List, Tuple
+
+import torch.nn as nn
+
+from torch import Tensor
+
+from compressai.entropy_models import EntropyBottleneck
+from compressai.registry import register_module
+
+from ..base import LatentCodec
+
+__all__ = [
+    "GainHyperLatentCodec",
+]
+
+
+@register_module("GainHyperLatentCodec")
+class GainHyperLatentCodec(LatentCodec):
+    """Entropy bottleneck codec with surrounding `h_a` and `h_s` transforms.
+
+    Gain-controlled side branch for hyperprior introduced in
+    `"Asymmetric Gained Deep Image Compression With Continuous Rate Adaptation"
+    <https://arxiv.org/abs/2003.02012>`_, by Ze Cui, Jing Wang,
+    Shangyin Gao, Bo Bai, Tiansheng Guo, and Yihui Feng, CVPR, 2021.
+
+    .. note:: ``GainHyperLatentCodec`` should be used inside
+       ``GainHyperpriorLatentCodec`` to construct a full hyperprior.
+
+    .. code-block:: none
+
+                       gain                        gain_inv
+                         │                             │
+                         ▼                             ▼
+               ┌───┐  z  │     ┌───┐ z_hat      z_hat  │       ┌───┐
+        y ──►──┤h_a├──►──×──►──┤ Q ├───►───····───►────×────►──┤h_s├──►── params
+               └───┘           └───┘        EB                 └───┘
+
+    """
+
+    entropy_bottleneck: EntropyBottleneck
+    h_a: nn.Module
+    h_s: nn.Module
+
+    def __init__(self, N: int, **kwargs):
+        super().__init__()
+        self._kwargs = kwargs
+        self.N = N
+        self._setdefault("entropy_bottleneck", lambda: EntropyBottleneck(N))
+        self._setdefault("h_a", nn.Identity)
+        self._setdefault("h_s", nn.Identity)
+
+    def forward(self, y: Tensor, gain: Tensor, gain_inv: Tensor) -> Dict[str, Any]:
+        z = self.h_a(y)
+        z = z * gain
+        z_hat, z_likelihoods = self.entropy_bottleneck(z)
+        z_hat = z_hat * gain_inv
+        params = self.h_s(z_hat)
+        return {"likelihoods": {"z": z_likelihoods}, "params": params}
+
+    def compress(self, y: Tensor, gain: Tensor, gain_inv: Tensor) -> Dict[str, Any]:
+        z = self.h_a(y)
+        z = z * gain
+        shape = z.size()[-2:]
+        z_strings = self.entropy_bottleneck.compress(z)
+        z_hat = self.entropy_bottleneck.decompress(z_strings, shape)
+        z_hat = z_hat * gain_inv
+        params = self.h_s(z_hat)
+        return {"strings": [z_strings], "shape": shape, "params": params}
+
+    def decompress(
+        self, strings: List[List[bytes]], shape: Tuple[int, int], gain_inv: Tensor
+    ) -> Dict[str, Any]:
+        (z_strings,) = strings
+        z_hat = self.entropy_bottleneck.decompress(z_strings, shape)
+        z_hat = z_hat * gain_inv
+        params = self.h_s(z_hat)
+        return {"params": params}

--- a/compressai/latent_codecs/gain/hyperprior.py
+++ b/compressai/latent_codecs/gain/hyperprior.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2021-2022, InterDigital Communications, Inc
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted (subject to the limitations in the disclaimer
+# below) provided that the following conditions are met:
+
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of InterDigital Communications, Inc nor the names of its
+#   contributors may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+
+# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+# THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+# NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from typing import Any, Dict, List, Mapping, Tuple
+
+from torch import Tensor
+
+from compressai.registry import register_module
+
+from ..base import LatentCodec
+from ..gaussian_conditional import GaussianConditionalLatentCodec
+from .hyper import GainHyperLatentCodec
+
+__all__ = [
+    "GainHyperpriorLatentCodec",
+]
+
+
+@register_module("GainHyperpriorLatentCodec")
+class GainHyperpriorLatentCodec(LatentCodec):
+    """Hyperprior codec constructed from latent codec for `y` that
+    compresses `y` using `params` from `hyper` branch.
+
+    Gain-controlled hyperprior introduced in
+    `"Asymmetric Gained Deep Image Compression With Continuous Rate Adaptation"
+    <https://arxiv.org/abs/2003.02012>`_, by Ze Cui, Jing Wang,
+    Shangyin Gao, Bo Bai, Tiansheng Guo, and Yihui Feng, CVPR, 2021.
+
+    .. code-block:: none
+
+                z_gain  z_gain_inv
+                   │        │
+                   ▼        ▼
+                  ┌┴────────┴┐
+            ┌──►──┤ lc_hyper ├──►─┐
+            │     └──────────┘    │
+            │                     │
+            │     y_gain          ▼ params   y_gain_inv
+            │        │            │              │
+            │        ▼            │              ▼
+            │        │         ┌──┴───┐          │
+        y ──┴────►───×───►─────┤ lc_y ├────►─────×─────►── y_hat
+                               └──────┘
+
+    By default, the following codec is constructed:
+
+    .. code-block:: none
+
+                        z_gain                      z_gain_inv
+                           │                             │
+                           ▼                             ▼
+                 ┌───┐  z  │ z_g ┌───┐ z_hat      z_hat  │       ┌───┐
+            ┌─►──┤h_a├──►──×──►──┤ Q ├───►───····───►────×────►──┤h_s├──┐
+            │    └───┘           └───┘        EB                 └───┘  │
+            │                                                           │
+            │                              ┌──────────────◄─────────────┘
+            │                              │            params
+            │                           ┌──┴──┐
+            │    y_gain                 │  EP │    y_gain_inv
+            │       │                   └──┬──┘        │
+            │       ▼                      │           ▼
+            │       │       ┌───┐          ▼           │
+        y ──┴───►───×───►───┤ Q ├────►────····───►─────×─────►── y_hat
+                            └───┘          GC
+
+    Common configurations of latent codecs include:
+     - entropy bottleneck `hyper` (default) and gaussian conditional `y` (default)
+     - entropy bottleneck `hyper` (default) and autoregressive `y`
+    """
+
+    latent_codec: Mapping[str, LatentCodec]
+
+    def __init__(self, N: int, **kwargs):
+        super().__init__()
+        self._kwargs = kwargs
+        self.N = N
+        self._set_group_defaults(
+            "latent_codec",
+            defaults={
+                "y": GaussianConditionalLatentCodec,
+                "hyper": lambda: GainHyperLatentCodec(N),
+            },
+        )
+
+    def forward(
+        self,
+        y: Tensor,
+        y_gain: Tensor,
+        z_gain: Tensor,
+        y_gain_inv: Tensor,
+        z_gain_inv: Tensor,
+    ) -> Dict[str, Any]:
+        hyper_out = self.latent_codec["hyper"](y, z_gain, z_gain_inv)
+        y_out = self.latent_codec["y"](y * y_gain, hyper_out["params"])
+        y_hat = y_out["y_hat"] * y_gain_inv
+        return {
+            "likelihoods": {
+                "y": y_out["likelihoods"]["y"],
+                "z": hyper_out["likelihoods"]["z"],
+            },
+            "y_hat": y_hat,
+        }
+
+    def compress(
+        self,
+        y: Tensor,
+        y_gain: Tensor,
+        z_gain: Tensor,
+        y_gain_inv: Tensor,
+        z_gain_inv: Tensor,
+    ) -> Dict[str, Any]:
+        hyper_out = self.latent_codec["hyper"].compress(y, z_gain, z_gain_inv)
+        y_out = self.latent_codec["y"].compress(y * y_gain, hyper_out["params"])
+        y_hat = y_out["y_hat"] * y_gain_inv
+        return {
+            "strings": [*y_out["strings"], *hyper_out["strings"]],
+            "shape": {"y": y_out["shape"], "hyper": hyper_out["shape"]},
+            "y_hat": y_hat,
+        }
+
+    def decompress(
+        self,
+        strings: List[List[bytes]],
+        shape: Dict[str, Tuple[int, ...]],
+        y_gain_inv: Tensor,
+        z_gain_inv: Tensor,
+    ) -> Dict[str, Any]:
+        *y_strings_, z_strings = strings
+        assert all(len(y_strings) == len(z_strings) for y_strings in y_strings_)
+        hyper_out = self.latent_codec["hyper"].decompress(
+            [z_strings], shape["hyper"], z_gain_inv
+        )
+        y_out = self.latent_codec["y"].decompress(
+            y_strings_, shape["y"], hyper_out["params"]
+        )
+        y_hat = y_out["y_hat"] * y_gain_inv
+        return {"y_hat": y_hat}

--- a/compressai/latent_codecs/gaussian_conditional.py
+++ b/compressai/latent_codecs/gaussian_conditional.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2021-2022, InterDigital Communications, Inc
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted (subject to the limitations in the disclaimer
+# below) provided that the following conditions are met:
+
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of InterDigital Communications, Inc nor the names of its
+#   contributors may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+
+# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+# THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+# NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from typing import Any, Dict, List, Tuple
+
+import torch.nn as nn
+
+from torch import Tensor
+
+from compressai.entropy_models import GaussianConditional
+from compressai.ops import quantize_ste
+from compressai.registry import register_module
+
+from .base import LatentCodec
+
+__all__ = [
+    "GaussianConditionalLatentCodec",
+]
+
+
+@register_module("GaussianConditionalLatentCodec")
+class GaussianConditionalLatentCodec(LatentCodec):
+    """Gaussian conditional for compressing latent ``y`` using ``ctx_params``.
+
+    Probability model for Gaussian of ``(scales, means)``.
+
+    Gaussian conditonal entropy model introduced in
+    `"Variational Image Compression with a Scale Hyperprior"
+    <https://arxiv.org/abs/1802.01436>`_,
+    by J. Balle, D. Minnen, S. Singh, S.J. Hwang, and N. Johnston,
+    International Conference on Learning Representations (ICLR), 2018.
+
+    .. note:: Unlike the original paper, which models only the scale
+       (i.e. "width") of the Gaussian, this implementation models both
+       the scale and the mean (i.e. "center") of the Gaussian.
+
+    .. code-block:: none
+
+                          ctx_params
+                              │
+                              ▼
+                              │
+                           ┌──┴──┐
+                           │  EP │
+                           └──┬──┘
+                              │
+               ┌───┐  y_hat   ▼
+        y ──►──┤ Q ├────►────····──►── y_hat
+               └───┘          GC
+
+    """
+
+    gaussian_conditional: GaussianConditional
+    entropy_parameters: nn.Module
+
+    def __init__(self, quantizer: str = "noise", **kwargs):
+        super().__init__()
+        self._kwargs = kwargs
+        self.quantizer = quantizer
+        self._setdefault("gaussian_conditional", lambda: GaussianConditional(None))
+        self._setdefault("entropy_parameters", nn.Identity)
+
+    def forward(self, y: Tensor, ctx_params: Tensor) -> Dict[str, Any]:
+        gaussian_params = self.entropy_parameters(ctx_params)
+        scales_hat, means_hat = gaussian_params.chunk(2, 1)
+        y_hat, y_likelihoods = self.gaussian_conditional(y, scales_hat, means=means_hat)
+        if self.quantizer == "ste":
+            y_hat = quantize_ste(y - means_hat) + means_hat
+        return {"likelihoods": {"y": y_likelihoods}, "y_hat": y_hat}
+
+    def compress(self, y: Tensor, ctx_params: Tensor) -> Dict[str, Any]:
+        gaussian_params = self.entropy_parameters(ctx_params)
+        scales_hat, means_hat = gaussian_params.chunk(2, 1)
+        indexes = self.gaussian_conditional.build_indexes(scales_hat)
+        y_strings = self.gaussian_conditional.compress(y, indexes, means_hat)
+        y_hat = self.gaussian_conditional.decompress(
+            y_strings, indexes, means=means_hat
+        )
+        return {"strings": [y_strings], "y_hat": y_hat}
+
+    def decompress(
+        self, strings: List[List[bytes]], shape: Tuple[int, int], ctx_params: Tensor
+    ) -> Dict[str, Any]:
+        (y_strings,) = strings
+        gaussian_params = self.entropy_parameters(ctx_params)
+        scales_hat, means_hat = gaussian_params.chunk(2, 1)
+        indexes = self.gaussian_conditional.build_indexes(scales_hat)
+        y_hat = self.gaussian_conditional.decompress(
+            y_strings, indexes, means=means_hat
+        )
+        assert y_hat.shape[2:4] == shape
+        return {"y_hat": y_hat}

--- a/compressai/latent_codecs/hyper.py
+++ b/compressai/latent_codecs/hyper.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2021-2022, InterDigital Communications, Inc
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted (subject to the limitations in the disclaimer
+# below) provided that the following conditions are met:
+
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of InterDigital Communications, Inc nor the names of its
+#   contributors may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+
+# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+# THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+# NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from typing import Any, Dict, List, Tuple
+
+import torch.nn as nn
+
+from torch import Tensor
+
+from compressai.entropy_models import EntropyBottleneck
+from compressai.registry import register_module
+
+from .base import LatentCodec
+
+__all__ = [
+    "HyperLatentCodec",
+]
+
+
+@register_module("HyperLatentCodec")
+class HyperLatentCodec(LatentCodec):
+    """Entropy bottleneck codec with surrounding `h_a` and `h_s` transforms.
+
+    "Hyper" side-information branch introduced in
+    `"Variational Image Compression with a Scale Hyperprior"
+    <https://arxiv.org/abs/1802.01436>`_,
+    by J. Balle, D. Minnen, S. Singh, S.J. Hwang, and N. Johnston,
+    International Conference on Learning Representations (ICLR), 2018.
+
+    .. note:: ``HyperLatentCodec`` should be used inside
+       ``HyperpriorLatentCodec`` to construct a full hyperprior.
+
+    .. code-block:: none
+
+               ┌───┐  z  ┌───┐ z_hat      z_hat ┌───┐
+        y ──►──┤h_a├──►──┤ Q ├───►───····───►───┤h_s├──►── params
+               └───┘     └───┘        EB        └───┘
+
+    """
+
+    entropy_bottleneck: EntropyBottleneck
+    h_a: nn.Module
+    h_s: nn.Module
+
+    def __init__(self, N: int, **kwargs):
+        super().__init__()
+        self._kwargs = kwargs
+        self.N = N
+        self._setdefault("entropy_bottleneck", lambda: EntropyBottleneck(N))
+        self._setdefault("h_a", nn.Identity)
+        self._setdefault("h_s", nn.Identity)
+
+    def forward(self, y: Tensor) -> Dict[str, Any]:
+        z = self.h_a(y)
+        z_hat, z_likelihoods = self.entropy_bottleneck(z)
+        params = self.h_s(z_hat)
+        return {"likelihoods": {"z": z_likelihoods}, "params": params}
+
+    def compress(self, y: Tensor) -> Dict[str, Any]:
+        z = self.h_a(y)
+        shape = z.size()[-2:]
+        z_strings = self.entropy_bottleneck.compress(z)
+        z_hat = self.entropy_bottleneck.decompress(z_strings, shape)
+        params = self.h_s(z_hat)
+        return {"strings": [z_strings], "shape": shape, "params": params}
+
+    def decompress(
+        self, strings: List[List[bytes]], shape: Tuple[int, int]
+    ) -> Dict[str, Any]:
+        (z_strings,) = strings
+        z_hat = self.entropy_bottleneck.decompress(z_strings, shape)
+        params = self.h_s(z_hat)
+        return {"params": params}

--- a/compressai/latent_codecs/hyperprior.py
+++ b/compressai/latent_codecs/hyperprior.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2021-2022, InterDigital Communications, Inc
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted (subject to the limitations in the disclaimer
+# below) provided that the following conditions are met:
+
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of InterDigital Communications, Inc nor the names of its
+#   contributors may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+
+# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+# THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+# NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from typing import Any, Dict, List, Mapping, Tuple
+
+from torch import Tensor
+
+from compressai.registry import register_module
+
+from .base import LatentCodec
+from .gaussian_conditional import GaussianConditionalLatentCodec
+from .hyper import HyperLatentCodec
+
+__all__ = [
+    "HyperpriorLatentCodec",
+]
+
+
+@register_module("HyperpriorLatentCodec")
+class HyperpriorLatentCodec(LatentCodec):
+    """Hyperprior codec constructed from latent codec for `y` that
+    compresses `y` using `params` from `hyper` branch.
+
+    Hyperprior entropy modeling introduced in
+    `"Variational Image Compression with a Scale Hyperprior"
+    <https://arxiv.org/abs/1802.01436>`_,
+    by J. Balle, D. Minnen, S. Singh, S.J. Hwang, and N. Johnston,
+    International Conference on Learning Representations (ICLR), 2018.
+
+    .. code-block:: none
+
+                 ┌──────────┐
+            ┌─►──┤ lc_hyper ├──►─┐
+            │    └──────────┘    │
+            │                    ▼ params
+            │                    │
+            │                 ┌──┴───┐
+        y ──┴───────►─────────┤ lc_y ├───►── y_hat
+                              └──────┘
+
+    By default, the following codec is constructed:
+
+    .. code-block:: none
+
+                 ┌───┐  z  ┌───┐ z_hat      z_hat ┌───┐
+            ┌─►──┤h_a├──►──┤ Q ├───►───····───►───┤h_s├──►─┐
+            │    └───┘     └───┘        EB        └───┘    │
+            │                                              │
+            │                  ┌──────────────◄────────────┘
+            │                  │            params
+            │               ┌──┴──┐
+            │               │  EP │
+            │               └──┬──┘
+            │                  │
+            │   ┌───┐  y_hat   ▼
+        y ──┴─►─┤ Q ├────►────····────►── y_hat
+                └───┘          GC
+
+    Common configurations of latent codecs include:
+     - entropy bottleneck ``hyper`` (default) and gaussian conditional ``y`` (default)
+     - entropy bottleneck ``hyper`` (default) and autoregressive ``y``
+    """
+
+    latent_codec: Mapping[str, LatentCodec]
+
+    def __init__(self, N: int, **kwargs):
+        super().__init__()
+        self._kwargs = kwargs
+        self.N = N
+        self._set_group_defaults(
+            "latent_codec",
+            defaults={
+                "y": GaussianConditionalLatentCodec,
+                "hyper": lambda: HyperLatentCodec(N),
+            },
+            save_direct=True,
+        )
+
+    def forward(self, y: Tensor) -> Dict[str, Any]:
+        hyper_out = self.latent_codec["hyper"](y)
+        y_out = self.latent_codec["y"](y, hyper_out["params"])
+        return {
+            "likelihoods": {
+                "y": y_out["likelihoods"]["y"],
+                "z": hyper_out["likelihoods"]["z"],
+            },
+            "y_hat": y_out["y_hat"],
+        }
+
+    def compress(self, y: Tensor) -> Dict[str, Any]:
+        hyper_out = self.latent_codec["hyper"].compress(y)
+        y_out = self.latent_codec["y"].compress(y, hyper_out["params"])
+        [z_strings] = hyper_out["strings"]
+        return {
+            "strings": [*y_out["strings"], z_strings],
+            "shape": {"y": y_out["shape"], "hyper": hyper_out["shape"]},
+            "y_hat": y_out["y_hat"],
+        }
+
+    def decompress(
+        self, strings: List[List[bytes]], shape: Dict[str, Tuple[int, ...]]
+    ) -> Dict[str, Any]:
+        *y_strings_, z_strings = strings
+        assert all(len(y_strings) == len(z_strings) for y_strings in y_strings_)
+        hyper_out = self.latent_codec["hyper"].decompress([z_strings], shape["hyper"])
+        y_out = self.latent_codec["y"].decompress(
+            y_strings_, shape["y"], hyper_out["params"]
+        )
+        return {"y_hat": y_out["y_hat"]}

--- a/compressai/latent_codecs/rasterscan.py
+++ b/compressai/latent_codecs/rasterscan.py
@@ -1,0 +1,306 @@
+# Copyright (c) 2021-2022, InterDigital Communications, Inc
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted (subject to the limitations in the disclaimer
+# below) provided that the following conditions are met:
+
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of InterDigital Communications, Inc nor the names of its
+#   contributors may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+
+# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+# THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+# NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from typing import Any, Callable, Dict, List, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from torch import Tensor
+from torch.utils.data.dataloader import default_collate
+
+from compressai.ans import BufferedRansEncoder, RansDecoder
+from compressai.entropy_models import GaussianConditional
+from compressai.layers import MaskedConv2d
+from compressai.registry import register_module
+
+from .base import LatentCodec
+
+__all__ = [
+    "RasterScanLatentCodec",
+]
+
+
+@register_module("RasterScanLatentCodec")
+class RasterScanLatentCodec(LatentCodec):
+    """Autoregression in raster-scan order with local decoded context.
+
+    PixelCNN context model introduced in
+    `"Pixel Recurrent Neural Networks"
+    <http://arxiv.org/abs/1601.06759>`_,
+    by Aaron van den Oord, Nal Kalchbrenner, and Koray Kavukcuoglu,
+    International Conference on Machine Learning (ICML), 2016.
+
+    First applied to learned image compression in
+    `"Joint Autoregressive and Hierarchical Priors for Learned Image
+    Compression" <https://arxiv.org/abs/1809.02736>`_,
+    by D. Minnen, J. Balle, and G.D. Toderici,
+    Adv. in Neural Information Processing Systems 31 (NeurIPS 2018).
+
+    .. code-block:: none
+
+                         ctx_params
+                             │
+                             ▼
+                             │ ┌───◄───┐
+                           ┌─┴─┴─┐  ┌──┴──┐
+                           │  EP │  │  CP │
+                           └──┬──┘  └──┬──┘
+                              │        │
+                              │        ▲
+               ┌───┐  y_hat   ▼        │
+        y ──►──┤ Q ├────►────····───►──┴──►── y_hat
+               └───┘          GC
+
+    """
+
+    gaussian_conditional: GaussianConditional
+    entropy_parameters: nn.Module
+    context_prediction: MaskedConv2d
+
+    def __init__(self, **kwargs):
+        super().__init__()
+        self._kwargs = kwargs
+        self._setdefault("gaussian_conditional", lambda: GaussianConditional(None))
+        self._setdefault("entropy_parameters", nn.Identity)
+        self._setdefault("context_prediction", lambda: None)
+        self.kernel_size = _reduce_seq(self.context_prediction.kernel_size)
+        self.padding = (self.kernel_size - 1) // 2
+
+    def forward(self, y: Tensor, params: Tensor) -> Dict[str, Any]:
+        y_hat = self.gaussian_conditional.quantize(
+            y, "noise" if self.training else "dequantize"
+        )
+        ctx_params = self.merge(params, self.context_prediction(y_hat))
+        gaussian_params = self.entropy_parameters(ctx_params)
+        scales_hat, means_hat = gaussian_params.chunk(2, 1)
+        _, y_likelihoods = self.gaussian_conditional(y, scales_hat, means=means_hat)
+        return {"likelihoods": {"y": y_likelihoods}, "y_hat": y_hat}
+
+    def compress(self, y: Tensor, ctx_params: Tensor) -> Dict[str, Any]:
+        n, _, y_height, y_width = y.shape
+        ds = [
+            self._compress_single(
+                y=y[i : i + 1, :, :, :],
+                params=ctx_params[i : i + 1, :, :, :],
+                gaussian_conditional=self.gaussian_conditional,
+                entropy_parameters=self.entropy_parameters,
+                context_prediction=self.context_prediction,
+                height=y_height,
+                width=y_width,
+                padding=self.padding,
+                kernel_size=self.kernel_size,
+                merge=self.merge,
+            )
+            for i in range(n)
+        ]
+        return default_collate(ds)
+
+    def _compress_single(self, **kwargs):
+        encoder = BufferedRansEncoder()
+        y_hat = raster_scan_compress_single_stream(encoder=encoder, **kwargs)
+        y_strings = encoder.flush()
+        return {"strings": [y_strings], "y_hat": y_hat.squeeze(0)}
+
+    def decompress(
+        self, strings: List[List[bytes]], shape: Tuple[int, int], ctx_params: Tensor
+    ) -> Dict[str, Any]:
+        (y_strings,) = strings
+        y_height, y_width = shape
+        ds = [
+            self._decompress_single(
+                y_string=y_strings[i],
+                params=ctx_params[i : i + 1, :, :, :],
+                gaussian_conditional=self.gaussian_conditional,
+                entropy_parameters=self.entropy_parameters,
+                context_prediction=self.context_prediction,
+                height=y_height,
+                width=y_width,
+                padding=self.padding,
+                kernel_size=self.kernel_size,
+                device=ctx_params.device,
+                merge=self.merge,
+            )
+            for i in range(len(y_strings))
+        ]
+        return default_collate(ds)
+
+    def _decompress_single(self, y_string, **kwargs):
+        decoder = RansDecoder()
+        decoder.set_stream(y_string)
+        y_hat = raster_scan_decompress_single_stream(decoder=decoder, **kwargs)
+        return {"y_hat": y_hat.squeeze(0)}
+
+    @staticmethod
+    def merge(*args):
+        return torch.cat(args, dim=1)
+
+
+def raster_scan_compress_single_stream(
+    encoder: BufferedRansEncoder,
+    y: Tensor,
+    params: Tensor,
+    *,
+    gaussian_conditional: GaussianConditional,
+    entropy_parameters: nn.Module,
+    context_prediction: MaskedConv2d,
+    height: int,
+    width: int,
+    padding: int,
+    kernel_size: int,
+    merge: Callable[..., Tensor] = lambda *args: torch.cat(args, dim=1),
+) -> Tensor:
+    """Compresses y and writes to encoder bitstream.
+
+    Returns:
+        The y_hat that will be reconstructed at the decoder.
+    """
+    assert height == y.shape[-2]
+    assert width == y.shape[-1]
+
+    cdf = gaussian_conditional.quantized_cdf.tolist()
+    cdf_lengths = gaussian_conditional.cdf_length.tolist()
+    offsets = gaussian_conditional.offset.tolist()
+    masked_weight = context_prediction.weight * context_prediction.mask
+
+    y_hat = _pad_2d(y, padding)
+
+    symbols_list = []
+    indexes_list = []
+
+    # Warning, this is slow...
+    # TODO: profile the calls to the bindings...
+    for h in range(height):
+        for w in range(width):
+            # only perform the mask convolution on a cropped tensor
+            # centered in (h, w)
+            y_crop = y_hat[:, :, h : h + kernel_size, w : w + kernel_size]
+            ctx_p = F.conv2d(
+                y_crop,
+                masked_weight,
+                context_prediction.bias,
+            )
+
+            # 1x1 conv for the entropy parameters prediction network, so
+            # we only keep the elements in the "center"
+            p = params[:, :, h : h + 1, w : w + 1]
+            gaussian_params = entropy_parameters(merge(p, ctx_p))
+            gaussian_params = gaussian_params.squeeze(3).squeeze(2)
+            scales_hat, means_hat = gaussian_params.chunk(2, 1)
+            indexes = gaussian_conditional.build_indexes(scales_hat)
+
+            y_crop = y_crop[:, :, padding, padding]
+            symbols = gaussian_conditional.quantize(y_crop, "symbols", means_hat)
+            y_hat_item = symbols + means_hat
+
+            hp = h + padding
+            wp = w + padding
+            y_hat[:, :, hp, wp] = y_hat_item
+
+            symbols_list.extend(symbols.squeeze().tolist())
+            indexes_list.extend(indexes.squeeze().tolist())
+
+    encoder.encode_with_indexes(symbols_list, indexes_list, cdf, cdf_lengths, offsets)
+
+    y_hat = _pad_2d(y_hat, -padding)
+    return y_hat
+
+
+def raster_scan_decompress_single_stream(
+    decoder: RansDecoder,
+    params: Tensor,
+    *,
+    gaussian_conditional: GaussianConditional,
+    entropy_parameters: nn.Module,
+    context_prediction: MaskedConv2d,
+    height: int,
+    width: int,
+    padding: int,
+    kernel_size: int,
+    device,
+    merge: Callable[..., Tensor] = lambda *args: torch.cat(args, dim=1),
+) -> Tensor:
+    """Decodes y_hat from decoder bitstream.
+
+    Returns:
+        The reconstructed y_hat.
+    """
+    cdf = gaussian_conditional.quantized_cdf.tolist()
+    cdf_lengths = gaussian_conditional.cdf_length.tolist()
+    offsets = gaussian_conditional.offset.tolist()
+    masked_weight = context_prediction.weight * context_prediction.mask
+
+    c = context_prediction.in_channels
+    shape = (1, c, height + 2 * padding, width + 2 * padding)
+    y_hat = torch.zeros(shape, device=device)
+
+    # Warning: this is slow due to the auto-regressive nature of the
+    # decoding... See more recent publication where they use an
+    # auto-regressive module on chunks of channels for faster decoding...
+    for h in range(height):
+        for w in range(width):
+            # only perform the mask convolution on a cropped tensor
+            # centered in (h, w)
+            y_crop = y_hat[:, :, h : h + kernel_size, w : w + kernel_size]
+            ctx_p = F.conv2d(
+                y_crop,
+                masked_weight,
+                context_prediction.bias,
+            )
+
+            # 1x1 conv for the entropy parameters prediction network, so
+            # we only keep the elements in the "center"
+            p = params[:, :, h : h + 1, w : w + 1]
+            gaussian_params = entropy_parameters(merge(p, ctx_p))
+            gaussian_params = gaussian_params.squeeze(3).squeeze(2)
+            scales_hat, means_hat = gaussian_params.chunk(2, 1)
+            indexes = gaussian_conditional.build_indexes(scales_hat)
+
+            symbols = decoder.decode_stream(
+                indexes.squeeze().tolist(), cdf, cdf_lengths, offsets
+            )
+            symbols = Tensor(symbols).reshape(1, -1)
+            y_hat_item = gaussian_conditional.dequantize(symbols, means_hat)
+
+            hp = h + padding
+            wp = w + padding
+            y_hat[:, :, hp, wp] = y_hat_item
+
+    y_hat = _pad_2d(y_hat, -padding)
+    return y_hat
+
+
+def _pad_2d(x: Tensor, padding: int) -> Tensor:
+    return F.pad(x, (padding, padding, padding, padding))
+
+
+def _reduce_seq(xs):
+    assert all(x == xs[0] for x in xs)
+    return xs[0]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,6 +27,7 @@ end-to-end compression research.
    ans
    datasets
    entropy_models
+   latent_codecs
    layers
    models
    ops

--- a/docs/source/latent_codecs.rst
+++ b/docs/source/latent_codecs.rst
@@ -1,0 +1,337 @@
+compressai.latent_codecs
+========================
+
+.. currentmodule:: compressai.latent_codecs
+
+
+A :py:class:`~LatentCodec` is an abstraction for compressing a latent space using some entropy modeling technique.
+A :py:class:`~LatentCodec` can be thought of as a miniature :py:class:`~compressai.models.base.CompressionModel`.
+In fact, it implements some of the same methods: ``forward``, ``compress``, and ``decompress``, as described in :ref:`define-custom-latent-codec`.
+By composing latent codecs, we can easily create more complex entropy models.
+
+CompressAI provides the following predefined :py:class:`~LatentCodec` subclasses:
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Module name
+     - Description
+   * - :py:class:`~EntropyBottleneckLatentCodec`
+     - Uses an :py:class:`~compressai.entropy_models.EntropyBottleneck` to encode ``y``.
+   * - :py:class:`~GaussianConditionalLatentCodec`
+     - Uses a :py:class:`~compressai.entropy_models.GaussianConditional` to encode ``y`` using ``(scale, mean)`` parameters.
+   * - :py:class:`~HyperLatentCodec`
+     - Uses an :py:class:`~compressai.entropy_models.EntropyBottleneck` to encode ``z``, with surrounding ``h_a`` and ``h_s`` transforms.
+   * - :py:class:`~HyperpriorLatentCodec`
+     - Uses an e.g. :py:class:`~GaussianConditionalLatentCodec` or :py:class:`~RasterScanLatentCodec` to encode ``y``, using ``(scale, mean)`` parameters generated from an e.g. :py:class:`~HyperLatentCodec`.
+   * - :py:class:`~RasterScanLatentCodec`
+     - Encodes ``y`` in raster-scan order using a PixelCNN-style autoregressive context model.
+   * - :py:class:`~GainHyperLatentCodec`
+     - Like :py:class:`~HyperLatentCodec`, but with trainable gain vectors for ``z``.
+   * - :py:class:`~GainHyperpriorLatentCodec`
+     - Like :py:class:`~HyperpriorLatentCodec`, but with trainable gain vectors for ``y``.
+
+
+Diagrams for some of the above predefined latent codecs:
+
+.. code-block:: none
+
+    HyperLatentCodec:
+
+               ┌───┐  z  ┌───┐ z_hat      z_hat ┌───┐
+        y ──►──┤h_a├──►──┤ Q ├───►───····───►───┤h_s├──►── params
+               └───┘     └───┘        EB        └───┘
+
+        Entropy bottleneck codec with surrounding `h_a` and `h_s` transforms.
+
+.. code-block:: none
+
+    GaussianConditionalLatentCodec:
+
+                          ctx_params
+                              │
+                              ▼
+                              │
+                           ┌──┴──┐
+                           │  EP │
+                           └──┬──┘
+                              │
+               ┌───┐  y_hat   ▼
+        y ──►──┤ Q ├────►────····──►── y_hat
+               └───┘          GC
+
+        Gaussian conditional for compressing latent `y` using `ctx_params`.
+
+.. code-block:: none
+
+    HyperpriorLatentCodec:
+
+                 ┌──────────┐
+            ┌─►──┤ lc_hyper ├──►─┐
+            │    └──────────┘    │
+            │                    ▼ params
+            │                    │
+            │                 ┌──┴───┐
+        y ──┴───────►─────────┤ lc_y ├───►── y_hat
+                              └──────┘
+
+        Composes a HyperLatentCodec and a "lc_y" latent codec such as
+        GaussianConditionalLatentCodec or RasterScanLatentCodec.
+
+.. code-block:: none
+
+    RasterScanLatentCodec:
+
+                         ctx_params
+                             │
+                             ▼
+                             │ ┌───◄───┐
+                           ┌─┴─┴─┐  ┌──┴──┐
+                           │  EP │  │  CP │
+                           └──┬──┘  └──┬──┘
+                              │        │
+                              │        ▲
+               ┌───┐  y_hat   ▼        │
+        y ──►──┤ Q ├────►────····───►──┴──►── y_hat
+               └───┘          GC
+
+
+Rationale
+---------
+
+This abstraction makes it easy to swap between different entropy models such as "factorized", "hyperprior", "raster scan autoregressive", "checkerboard", or "channel conditional groups".
+
+It also aids in composition: we may now easily take any complicated composition of the above :py:class:`~LatentCodec` subclasses. For example, we may create models containing multiple hyperprior branches (`Hu et al., 2020`_), or a "channel conditional group" context model which encodes each group using "raster-scan" (`Minnen et al., 2020`_) or "checkerboard" (`He et al., 2022`_) autoregression, and so on.
+
+Lastly, it reduces code duplication, and favors `composition instead of inheritance`_.
+
+.. _Hu et al., 2020: https://huzi96.github.io/coarse-to-fine-compression.html
+.. _Minnen et al., 2020: https://arxiv.org/abs/2007.08739
+.. _He et al., 2022: https://arxiv.org/abs/2203.10886
+.. _composition instead of inheritance: https://en.wikipedia.org/wiki/Composition_over_inheritance
+
+
+Example models
+--------------
+
+A simple VAE model with an arbitrary latent codec can be implemented as follows:
+
+.. code-block:: python
+
+    class SimpleVAECompressionModel(CompressionModel):
+        """Simple VAE model with arbitrary latent codec.
+
+        .. code-block:: none
+
+                   ┌───┐  y  ┌────┐ y_hat ┌───┐
+            x ──►──┤g_a├──►──┤ lc ├───►───┤g_s├──►── x_hat
+                   └───┘     └────┘       └───┘
+        """
+
+        g_a: nn.Module
+        g_s: nn.Module
+        latent_codec: LatentCodec
+
+        def forward(self, x):
+            y = self.g_a(x)
+            y_out = self.latent_codec(y)
+            y_hat = y_out["y_hat"]
+            x_hat = self.g_s(y_hat)
+            return {
+                "x_hat": x_hat,
+                "likelihoods": y_out["likelihoods"],
+            }
+
+        def compress(self, x):
+            y = self.g_a(x)
+            outputs = self.latent_codec.compress(y)
+            return outputs
+
+        def decompress(self, strings, shape):
+            y_out = self.latent_codec.decompress(strings, shape)
+            y_hat = y_out["y_hat"]
+            x_hat = self.g_s(y_hat).clamp_(0, 1)
+            return {
+                "x_hat": x_hat,
+            }
+
+This pattern is so common that CompressAI provides it via the import:
+
+.. code-block:: python
+
+    from compressai.models.base import SimpleVAECompressionModel
+
+Using :py:class:`~compressai.models.base.SimpleVAECompressionModel`, some Google-style VAE models may be implemented as follows:
+
+.. code-block:: python
+
+    @register_model("bmshj2018-factorized")
+    class FactorizedPrior(SimpleVAECompressionModel):
+        def __init__(self, N, M, **kwargs):
+            super().__init__(**kwargs)
+
+            self.g_a = nn.Sequential(...)
+            self.g_s = nn.Sequential(...)
+
+            self.latent_codec = EntropyBottleneckLatentCodec(N)
+
+
+.. code-block:: python
+
+    @register_model("mbt2018-mean")
+    class MeanScaleHyperprior(SimpleVAECompressionModel):
+        def __init__(self, N, M, **kwargs):
+            super().__init__(**kwargs)
+
+            self.g_a = nn.Sequential(...)
+            self.g_s = nn.Sequential(...)
+            h_a = nn.Sequential(...)
+            h_s = nn.Sequential(...)
+
+            self.latent_codec = HyperpriorLatentCodec(
+                N=N,
+
+                # A HyperpriorLatentCodec is made of "hyper" and "y" latent codecs.
+                latent_codec={
+                    # Side-information branch with entropy bottleneck for "z":
+                    "hyper": HyperLatentCodec(
+                        N,
+                        h_a=h_a,
+                        h_s=h_s,
+                        entropy_bottleneck=EntropyBottleneck(N),
+                    ),
+                    # Encode y using GaussianConditional:
+                    "y": GaussianConditionalLatentCodec(),
+                },
+            )
+
+
+.. code-block:: python
+
+    @register_model("mbt2018")
+    class JointAutoregressiveHierarchicalPriors(SimpleVAECompressionModel):
+        def __init__(self, N, M, **kwargs):
+            super().__init__(**kwargs)
+
+            self.g_a = nn.Sequential(...)
+            self.g_s = nn.Sequential(...)
+            h_a = nn.Sequential(...)
+            h_s = nn.Sequential(...)
+
+            self.latent_codec = HyperpriorLatentCodec(
+                N=N,
+
+                # A HyperpriorLatentCodec is made of "hyper" and "y" latent codecs.
+                latent_codec={
+                    # Side-information branch with entropy bottleneck for "z":
+                    "hyper": HyperLatentCodec(
+                        N,
+                        h_a=h_a,
+                        h_s=h_s,
+                        entropy_bottleneck=EntropyBottleneck(N),
+                    ),
+                    # Encode y using autoregression in raster-scan order:
+                    "y": RasterScanLatentCodec(
+                        entropy_parameters=nn.Sequential(...),
+                        context_prediction=MaskedConv2d(
+                            M, M * 2, kernel_size=5, padding=2, stride=1
+                        ),
+                    ),
+                },
+            )
+
+
+.. _define-custom-latent-codec:
+
+Defining a custom latent codec
+------------------------------
+
+Latent codecs should inherit from the abstract base class :py:class:`~LatentCodec`, which is defined as:
+
+.. code-block:: python
+
+    class LatentCodec(nn.Module, _SetDefaultMixin):
+        def forward(self, y: Tensor, *args, **kwargs) -> Dict[str, Any]:
+            raise NotImplementedError
+
+        def compress(self, y: Tensor, *args, **kwargs) -> Dict[str, Any]:
+            raise NotImplementedError
+
+        def decompress(
+            self, strings: List[List[bytes]], shape: Any, *args, **kwargs
+        ) -> Dict[str, Any]:
+            raise NotImplementedError
+
+
+Like :py:class:`~compressai.models.base.CompressionModel`, a subclass of :py:class:`~LatentCodec` should implement:
+
+- ``forward``: differentiable function for training, returning a ``dict`` in the form of:
+
+  .. code-block:: python
+
+      {
+          "likelihoods": {
+              "y": y_likelihoods,
+              ...
+          },
+          "y_hat": y_hat,
+      }
+
+- ``compress``: compressor to generate bitstreams from input tensor, returning a ``dict`` in the form of:
+
+  .. code-block:: python
+
+      {
+          "strings": [y_strings, z_strings],
+          "shape": ...,
+      }
+
+- ``decompress``: decompressor to reconstruct the input tensors using the bitstreams, returning a ``dict`` in the form of:
+
+  .. code-block:: python
+
+      {
+          "y_hat": y_hat,
+      }
+
+Please refer to any of the predefined latent codecs for more concrete examples.
+
+
+----
+
+
+EntropyBottleneckLatentCodec
+----------------------------
+.. autoclass:: EntropyBottleneckLatentCodec
+
+
+GaussianConditionalLatentCodec
+------------------------------
+.. autoclass:: GaussianConditionalLatentCodec
+
+
+HyperLatentCodec
+----------------
+.. autoclass:: HyperLatentCodec
+
+
+HyperpriorLatentCodec
+---------------------
+.. autoclass:: HyperpriorLatentCodec
+
+
+RasterScanLatentCodec
+---------------------
+.. autoclass:: RasterScanLatentCodec
+
+
+GainHyperLatentCodec
+--------------------
+.. autoclass:: GainHyperLatentCodec
+
+
+GainHyperpriorLatentCodec
+-------------------------
+.. autoclass:: GainHyperpriorLatentCodec
+

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -18,39 +18,36 @@ SimpleVAECompressionModel
 FactorizedPrior
 ----------------
 .. autoclass:: FactorizedPrior
-    :members:
 
 
 ScaleHyperprior
 ---------------
 .. autoclass:: ScaleHyperprior
-    :members:
 
 
 MeanScaleHyperprior
 -------------------
 .. autoclass:: MeanScaleHyperprior
-    :members:
 
 
 JointAutoregressiveHierarchicalPriors
 -------------------------------------
 .. autoclass:: JointAutoregressiveHierarchicalPriors
-    :members:
+
 
 Cheng2020Anchor
 ---------------
 .. autoclass:: Cheng2020Anchor
-    :members:
+
 
 Cheng2020Attention
 ------------------
 .. autoclass:: Cheng2020Attention
-    :members:
+
 
 .. currentmodule:: compressai.models.video
 
 ScaleSpaceFlow
 ------------------
 .. autoclass:: ScaleSpaceFlow
-    :members:
+

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -10,6 +10,11 @@ CompressionModel
     :members:
 
 
+SimpleVAECompressionModel
+-------------------------
+.. autoclass:: SimpleVAECompressionModel
+
+
 FactorizedPrior
 ----------------
 .. autoclass:: FactorizedPrior


### PR DESCRIPTION
Latent codecs should inherit from the abstract base class `LatentCodec`, which is defined as:

```python
class LatentCodec(nn.Module, _SetDefaultMixin):
    def forward(self, y: Tensor, *args, **kwargs) -> Dict[str, Any]:
        raise NotImplementedError

    def compress(self, y: Tensor, *args, **kwargs) -> Dict[str, Any]:
        raise NotImplementedError

    def decompress(
        self, strings: List[List[bytes]], shape: Any, *args, **kwargs
    ) -> Dict[str, Any]:
        raise NotImplementedError
```

Examples of some predefined latent codecs:

```none
HyperLatentCodec:

               ┌───┐  z  ┌───┐ z_hat      z_hat ┌───┐
        y ──►──┤h_a├──►──┤ Q ├───►───·⋯⋯·───►───┤h_s├──►── params
               └───┘     └───┘        EB        └───┘

    Entropy bottleneck codec with surrounding `h_a` and `h_s` transforms.

GaussianConditionalLatentCodec:

                      ctx_params
                          │
                          ▼
                          │
                       ┌──┴──┐
                       │  EP │
                       └──┬──┘
                          │
           ┌───┐  y_hat   ▼
    y ──►──┤ Q ├────►────·⋯⋯·──►── y_hat
           └───┘          GC

    Gaussian conditional for compressing latent `y` using `ctx_params`.

HyperpriorLatentCodec:

             ┌──────────┐
        ┌─►──┤ lc_hyper ├──►─┐
        │    └──────────┘    │
        │                    ▼ params
        │                    │
        │                 ┌──┴───┐
    y ──┴───────►─────────┤ lc_y ├───►── y_hat
                          └──────┘

    Composes a HyperLatentCodec and a "lc_y" latent codec such as
    GaussianConditionalLatentCodec or RasterScanAutoregressiveLatentCodec.

RasterScanAutoregressiveLatentCodec:

                     ctx_params
                         │
                         ▼
                         │ ┌───◄───┐
                       ┌─┴─┴─┐  ┌──┴──┐
                       │  EP │  │  CP │
                       └──┬──┘  └──┬──┘
                          │        │
                          │        ▲
           ┌───┐  y_hat   ▼        │
    y ──►──┤ Q ├────►────·⋯⋯·───►──┴──►── y_hat
           └───┘          GC
```

Example usage:

```python
from compressai.models.base import SimpleVAECompressionModel


class ExampleModel(SimpleVAECompressionModel):
    def __init__(self, N=128, M=192, **kwargs):
        super().__init__(**kwargs)

        self.g_a = nn.Sequential(...)
        self.g_s = nn.Sequential(...)

        self.latent_codec = HyperpriorLatentCodec(
            N=N,
            latent_codec={

                # Side-information branch with entropy bottleneck for "z":
                "hyper": HyperLatentCodec(
                    N,
                    h_a=nn.Sequential(...),
                    h_s=nn.Sequential(...),
                    entropy_bottleneck=EntropyBottleneck(N),
                ),

                # Encode y using standard hyperprior with GaussianConditional:
                "y": GaussianConditionalLatentCodec(),

                # Or perhaps with raster-scan autoregression instead:
                "y": RasterScanLatentCodec(
                    entropy_parameters=nn.Sequential(...),
                    context_prediction=MaskedConv2d(
                        M, M * 2, kernel_size=5, padding=2, stride=1
                    ),
                ),

            },
        )
```

This abstraction makes it easy for users to swap between different `LatentCodec` architectures such as "factorized", "hyperprior", "raster scan autoregressive", "checkerboard", or "channel groups".

It also aids in composition: users may now easily take any complicated composition of the above `LatentCodec`s, and create models containing e.g. multiple hyperprior branches, "channel group" context models which may encode groups using "raster-scan autoregression" or "checkerboard", and so on.

Furthermore, it reduces duplication in `CompressionModel`s since they may now simply reference an existing `LatentCodec` that defines behavior related to `entropy_bottleneck`, `gaussian_conditional`, or the autoregressive loop.

---

Tasks:

- [ ] Verify that I didn't break anything.
- [x] gh-pages / documentation / examples
  - [x] Example implementation with Google models.

---

Tasks for later PRs:

- [ ] Implement:
  - [ ] `ChannelConditionalGroupsLatentCodec` (David Minnen and Saurabh Singh. Channel-wise autoregressive entropy models for learned image compression. 2020.), also used in (Dailan He, Ziming Yang, Weikun Peng, Rui Ma, Hongwei Qin, Yan Wang. ELIC: Efficient Learned Image Compression with Unevenly Grouped Space-Channel Contextual Adaptive Coding. 2022.).
  - [x] `CheckerboardLatentCodec` (Dailan He, Yaoyan Zheng, Baocheng Sun, Yan Wang, and Hongwei Qin. Checkerboard Context Model for Efficient Learned Image Compression. 2021.)
- [ ] Train models (for zoo):
  - [ ] Cheng2020AnchorCheckerboard [on hold]
  - [ ] Cheng2020AnchorELIC [on hold]
- [ ] Refactor the raster scan autoregressive loop from original google.py model to reduce code duplication, and so non-users of `LatentCodec` can also benefit a bit.
