### PR TITLE
fix some bugs in bench

### DIFF
--- a/compressai/utils/bench/__main__.py
+++ b/compressai/utils/bench/__main__.py
@@ -135,8 +135,7 @@ def setup_common_args(parser):
         "--qps",
         dest="qps",
         type=str,
-        default=["75"],
-        nargs="+",
+        default="75",
         help="list of quality/quantization parameter (default: %(default)s)",
     )
     parser.add_argument(
@@ -158,10 +157,11 @@ def main(argv):
 
     codec_cls = next(c for c in codecs if c.__name__.lower() == args.codec)
     codec = codec_cls(args)
+    qps = [int(q) for q in args.qps.split(",") if q]
     results = collect(
         codec,
         args.dataset,
-        sorted(args.qps),
+        sorted(qps),
         args.metrics,
         args.num_jobs,
     )

--- a/compressai/utils/bench/__main__.py
+++ b/compressai/utils/bench/__main__.py
@@ -135,7 +135,8 @@ def setup_common_args(parser):
         "--qps",
         dest="qps",
         type=str,
-        default="75",
+        default=["75"],
+        nargs="+",
         help="list of quality/quantization parameter (default: %(default)s)",
     )
     parser.add_argument(
@@ -157,11 +158,10 @@ def main(argv):
 
     codec_cls = next(c for c in codecs if c.__name__.lower() == args.codec)
     codec = codec_cls(args)
-    qps = [int(q) for q in args.qps.split(",") if q]
     results = collect(
         codec,
         args.dataset,
-        sorted(qps),
+        sorted(args.qps),
         args.metrics,
         args.num_jobs,
     )

--- a/compressai/utils/bench/codecs.py
+++ b/compressai/utils/bench/codecs.py
@@ -398,7 +398,7 @@ class BPG(BinaryCodec):
         return args
 
     def _get_encode_cmd(self, in_filepath, quality, out_filepath):
-        if not 0 <= quality <= 51:
+        if not 0 <= int(quality) <= 51:
             raise ValueError(f"Invalid quality value: {quality} (0,51)")
         cmd = [
             self.encoder_path,

--- a/compressai/utils/bench/codecs.py
+++ b/compressai/utils/bench/codecs.py
@@ -257,6 +257,10 @@ class BinaryCodec(Codec):
     def name(self):
         raise NotImplementedError()
 
+    @classmethod
+    def setup_args(cls, _parser):
+        pass
+
     def _run_impl(self, in_filepath, quality):
         fd0, png_filepath = mkstemp(suffix=".png")
         fd1, out_filepath = mkstemp(suffix=self.fmt)

--- a/examples/run-benchmarks.sh
+++ b/examples/run-benchmarks.sh
@@ -96,57 +96,65 @@ BPGDEC="$(which bpgdec)"
 AV1_BIN_DIR="${HOME}/av1/aom/build_gcc"
 
 jpeg() {
+    qps=`echo $(seq 5 5 95) | awk '{gsub(/ /, ",");print $0}'`
     python3 -m compressai.utils.bench jpeg "$dataset"            \
-        -q $(seq 5 5 95) -j "$NJOBS" > "results/${dataset_name}/jpeg.json"
+        -q $qps -j "$NJOBS" > "results/${dataset_name}/jpeg.json"
 }
 
 jpeg2000() {
+    qps=`echo $(seq 5 5 95) | awk '{gsub(/ /, ",");print $0}'`
     python3 -m compressai.utils.bench jpeg2000 "$dataset"        \
-        -q $(seq 5 5 95) -j "$NJOBS" > "results/${dataset_name}/jpeg2000.json"
+        -q $qps -j "$NJOBS" > "results/${dataset_name}/jpeg2000.json"
 }
 
 webp() {
+    qps=`echo $(seq 5 5 95) | awk '{gsub(/ /, ",");print $0}'`
     python3 -m compressai.utils.bench webp "$dataset"            \
-        -q $(seq 5 5 95) -j "$NJOBS" > "results/${dataset_name}/webp.json"
+        -q $qps -j "$NJOBS" > "results/${dataset_name}/webp.json"
 }
 
 bpg() {
     if [ -z ${BPGENC+x} ] || [ -z ${BPGDEC+x} ]; then echo "install libBPG"; exit 1; fi
+    qps=`echo $(seq 47 -5 12) | awk '{gsub(/ /, ",");print $0}'`
     python3 -m compressai.utils.bench bpg "$dataset"             \
-        -q $(seq 47 -5 12) -m "$1" -e "$2" -c "$3"               \
-        --encoder-path "$BPGENC"                                \
-        --decoder-path "$BPGDEC"                                \
+        -q $qps -m "$1" -e "$2" -c "$3"                          \
+        --encoder-path "$BPGENC"                                 \
+        --decoder-path "$BPGDEC"                                 \
         -j "$NJOBS" > "results/${dataset_name}/$4"
 }
 
 hm() {
     if [ -z ${HM_BIN_DIR+x} ]; then echo "set HM bin directory HM_BIN_DIR"; exit 1; fi
     echo "using HM version $HM_VERSION"
+    qps=`echo $(seq 47 -5 12) | awk '{gsub(/ /, ",");print $0}'`
     python3 -m compressai.utils.bench hm "$dataset"             \
-        -q $(seq 47 -5 12) -b "$HM_BIN_DIR" -c "$HM_CFG"         \
+        -q $qps -b "$HM_BIN_DIR" -c "$HM_CFG"                   \
         -j "$NJOBS" > "results/${dataset_name}/hm.json"
 }
 
 vtm() {
     if [ -z ${VTM_BIN_DIR+x} ]; then echo "set VTM bin directory VTM_BIN_DIR"; exit 1; fi
     echo "using VTM version $VTM_VERSION"
+    qps=`echo $(seq 47 -5 12) | awk '{gsub(/ /, ",");print $0}'`
     python3 -m compressai.utils.bench vtm "$dataset"            \
-        -q $(seq 47 -5 12) -b "$VTM_BIN_DIR" -c "$VTM_CFG"       \
+        -q $qps -b "$VTM_BIN_DIR" -c "$VTM_CFG"                 \
         -j "$NJOBS" > "results/${dataset_name}/vtm.json"
 }
 
 av1() {
     if [ -z ${AV1_BIN_DIR+x} ]; then echo "set AV1 bin directory AV1_BIN_DIR"; exit 1; fi
+    qps=`echo $(seq 62 -5 7) | awk '{gsub(/ /, ",");print $0}'`
     python3 -m compressai.utils.bench av1 "$dataset"            \
-        -q $(seq 62 -5 7) -b "${AV1_BIN_DIR}"       \
+        -q $qps -b "${AV1_BIN_DIR}"                             \
         -j "$NJOBS" > "results/${dataset_name}/av1.json"
 }
 
 tfci() {
     if [ -z ${TFCI_SCRIPT+x} ]; then echo "set TFCI_SCRIPT bin path"; exit 1; fi
+    qps=`echo $(seq 1 8) | awk '{gsub(/ /, ",");print $0}'`
     python3 -m compressai.utils.bench tfci "$dataset"           \
         --path "$TFCI_SCRIPT" --model "$1"                      \
-        -q $(seq 1 8) -j "$NJOBS" > "results/${dataset_name}/official-$1.json"
+        -q $qps -j "$NJOBS" > "results/${dataset_name}/official-$1.json"
 }
 
 mkdir -p "results/${dataset_name}"

--- a/examples/run-benchmarks.sh
+++ b/examples/run-benchmarks.sh
@@ -95,41 +95,25 @@ BPGDEC="$(which bpgdec)"
 # edit below to provide the path to the chosen version of VTM
 AV1_BIN_DIR="${HOME}/av1/aom/build_gcc"
 
-gen_qps(){
-    if [ $# -eq 2 ]; then
-        qps=`echo $(seq $1 $2) | awk '{gsub(/ /, ",");print $0}'`
-    elif [ $# -eq 3 ]; then
-        qps=`echo $(seq $1 $2 $3) | awk '{gsub(/ /, ",");print $0}'`
-    else
-        echo "gen_qps: invalid number of arguments"
-        exit 1
-    fi
-    echo $qps
-}
-
 jpeg() {
-    qps=`gen_qps 5 5 95`
     python3 -m compressai.utils.bench jpeg "$dataset"            \
-        -q $qps -j "$NJOBS" > "results/${dataset_name}/jpeg.json"
+        -q $(seq -s, 5 5 95) -j "$NJOBS" > "results/${dataset_name}/jpeg.json"
 }
 
 jpeg2000() {
-    qps=`gen_qps 5 5 95`
     python3 -m compressai.utils.bench jpeg2000 "$dataset"        \
-        -q $qps -j "$NJOBS" > "results/${dataset_name}/jpeg2000.json"
+        -q $(seq -s, 5 5 95) -j "$NJOBS" > "results/${dataset_name}/jpeg2000.json"
 }
 
 webp() {
-    qps=`gen_qps 5 5 95`
     python3 -m compressai.utils.bench webp "$dataset"            \
-        -q $qps -j "$NJOBS" > "results/${dataset_name}/webp.json"
+        -q $(seq -s, 5 5 95) -j "$NJOBS" > "results/${dataset_name}/webp.json"
 }
 
 bpg() {
     if [ -z ${BPGENC+x} ] || [ -z ${BPGDEC+x} ]; then echo "install libBPG"; exit 1; fi
-    qps=`gen_qps 5 5 95`
     python3 -m compressai.utils.bench bpg "$dataset"             \
-        -q $qps -m "$1" -e "$2" -c "$3"                          \
+        -q $(seq -s, 47 -5 12) -m "$1" -e "$2" -c "$3"           \
         --encoder-path "$BPGENC"                                 \
         --decoder-path "$BPGDEC"                                 \
         -j "$NJOBS" > "results/${dataset_name}/$4"
@@ -138,35 +122,31 @@ bpg() {
 hm() {
     if [ -z ${HM_BIN_DIR+x} ]; then echo "set HM bin directory HM_BIN_DIR"; exit 1; fi
     echo "using HM version $HM_VERSION"
-    qps=`gen_qps 47 -5 12`
     python3 -m compressai.utils.bench hm "$dataset"             \
-        -q $qps -b "$HM_BIN_DIR" -c "$HM_CFG"                   \
+        -q $(seq -s, 47 -5 12) -b "$HM_BIN_DIR" -c "$HM_CFG"    \
         -j "$NJOBS" > "results/${dataset_name}/hm.json"
 }
 
 vtm() {
     if [ -z ${VTM_BIN_DIR+x} ]; then echo "set VTM bin directory VTM_BIN_DIR"; exit 1; fi
     echo "using VTM version $VTM_VERSION"
-    qps=`gen_qps 47 -5 12`
     python3 -m compressai.utils.bench vtm "$dataset"            \
-        -q $qps -b "$VTM_BIN_DIR" -c "$VTM_CFG"                 \
+        -q $(seq -s, 47 -5 12) -b "$VTM_BIN_DIR" -c "$VTM_CFG"  \
         -j "$NJOBS" > "results/${dataset_name}/vtm.json"
 }
 
 av1() {
     if [ -z ${AV1_BIN_DIR+x} ]; then echo "set AV1 bin directory AV1_BIN_DIR"; exit 1; fi
-    qps=`gen_qps 62 -5 7`
     python3 -m compressai.utils.bench av1 "$dataset"            \
-        -q $qps -b "${AV1_BIN_DIR}"                             \
+        -q $(seq -s, 62 -5 7) -b "${AV1_BIN_DIR}"               \
         -j "$NJOBS" > "results/${dataset_name}/av1.json"
 }
 
 tfci() {
     if [ -z ${TFCI_SCRIPT+x} ]; then echo "set TFCI_SCRIPT bin path"; exit 1; fi
-    qps=`gen_qps 1 8`
     python3 -m compressai.utils.bench tfci "$dataset"           \
         --path "$TFCI_SCRIPT" --model "$1"                      \
-        -q $qps -j "$NJOBS" > "results/${dataset_name}/official-$1.json"
+        -q $(seq -s, 1 8) -j "$NJOBS" > "results/${dataset_name}/official-$1.json"
 }
 
 mkdir -p "results/${dataset_name}"

--- a/examples/run-benchmarks.sh
+++ b/examples/run-benchmarks.sh
@@ -95,27 +95,39 @@ BPGDEC="$(which bpgdec)"
 # edit below to provide the path to the chosen version of VTM
 AV1_BIN_DIR="${HOME}/av1/aom/build_gcc"
 
+gen_qps(){
+    if [ $# -eq 2 ]; then
+        qps=`echo $(seq $1 $2) | awk '{gsub(/ /, ",");print $0}'`
+    elif [ $# -eq 3 ]; then
+        qps=`echo $(seq $1 $2 $3) | awk '{gsub(/ /, ",");print $0}'`
+    else
+        echo "gen_qps: invalid number of arguments"
+        exit 1
+    fi
+    echo $qps
+}
+
 jpeg() {
-    qps=`echo $(seq 5 5 95) | awk '{gsub(/ /, ",");print $0}'`
+    qps=`gen_qps 5 5 95`
     python3 -m compressai.utils.bench jpeg "$dataset"            \
         -q $qps -j "$NJOBS" > "results/${dataset_name}/jpeg.json"
 }
 
 jpeg2000() {
-    qps=`echo $(seq 5 5 95) | awk '{gsub(/ /, ",");print $0}'`
+    qps=`gen_qps 5 5 95`
     python3 -m compressai.utils.bench jpeg2000 "$dataset"        \
         -q $qps -j "$NJOBS" > "results/${dataset_name}/jpeg2000.json"
 }
 
 webp() {
-    qps=`echo $(seq 5 5 95) | awk '{gsub(/ /, ",");print $0}'`
+    qps=`gen_qps 5 5 95`
     python3 -m compressai.utils.bench webp "$dataset"            \
         -q $qps -j "$NJOBS" > "results/${dataset_name}/webp.json"
 }
 
 bpg() {
     if [ -z ${BPGENC+x} ] || [ -z ${BPGDEC+x} ]; then echo "install libBPG"; exit 1; fi
-    qps=`echo $(seq 47 -5 12) | awk '{gsub(/ /, ",");print $0}'`
+    qps=`gen_qps 5 5 95`
     python3 -m compressai.utils.bench bpg "$dataset"             \
         -q $qps -m "$1" -e "$2" -c "$3"                          \
         --encoder-path "$BPGENC"                                 \
@@ -126,7 +138,7 @@ bpg() {
 hm() {
     if [ -z ${HM_BIN_DIR+x} ]; then echo "set HM bin directory HM_BIN_DIR"; exit 1; fi
     echo "using HM version $HM_VERSION"
-    qps=`echo $(seq 47 -5 12) | awk '{gsub(/ /, ",");print $0}'`
+    qps=`gen_qps 47 -5 12`
     python3 -m compressai.utils.bench hm "$dataset"             \
         -q $qps -b "$HM_BIN_DIR" -c "$HM_CFG"                   \
         -j "$NJOBS" > "results/${dataset_name}/hm.json"
@@ -135,7 +147,7 @@ hm() {
 vtm() {
     if [ -z ${VTM_BIN_DIR+x} ]; then echo "set VTM bin directory VTM_BIN_DIR"; exit 1; fi
     echo "using VTM version $VTM_VERSION"
-    qps=`echo $(seq 47 -5 12) | awk '{gsub(/ /, ",");print $0}'`
+    qps=`gen_qps 47 -5 12`
     python3 -m compressai.utils.bench vtm "$dataset"            \
         -q $qps -b "$VTM_BIN_DIR" -c "$VTM_CFG"                 \
         -j "$NJOBS" > "results/${dataset_name}/vtm.json"
@@ -143,7 +155,7 @@ vtm() {
 
 av1() {
     if [ -z ${AV1_BIN_DIR+x} ]; then echo "set AV1 bin directory AV1_BIN_DIR"; exit 1; fi
-    qps=`echo $(seq 62 -5 7) | awk '{gsub(/ /, ",");print $0}'`
+    qps=`gen_qps 62 -5 7`
     python3 -m compressai.utils.bench av1 "$dataset"            \
         -q $qps -b "${AV1_BIN_DIR}"                             \
         -j "$NJOBS" > "results/${dataset_name}/av1.json"
@@ -151,7 +163,7 @@ av1() {
 
 tfci() {
     if [ -z ${TFCI_SCRIPT+x} ]; then echo "set TFCI_SCRIPT bin path"; exit 1; fi
-    qps=`echo $(seq 1 8) | awk '{gsub(/ /, ",");print $0}'`
+    qps=`gen_qps 1 8`
     python3 -m compressai.utils.bench tfci "$dataset"           \
         --path "$TFCI_SCRIPT" --model "$1"                      \
         -q $qps -j "$NJOBS" > "results/${dataset_name}/official-$1.json"


### PR DESCRIPTION
When I used `bash examples/run-benchmarks.sh {dataset} jpeg2000` to run benchmark, I found there are two questions in bench.

1. `run-benchmarks.sh` uses seq to set qps, so args.qps should be a list in `compressai/utils/bench/__main__.py`
2. `__main__.py` raises `TypeError: Can't instantiate abstract class JPEG2000 with abstract method setup_args` in line 160: `codec = codec_cls(args)`. It means  I was trying to create an instance of an abstract class that has abstract methods not implemented by its subclass. I checked the code and found that the function `setup_args` was not implemented.
3. Type of quality in bpg codec is `str`. We must convert it to `int` before comparing.