### PR TITLE
feat: fast EntropyBottleneck aux_loss minimization via bisection search

### DIFF
--- a/tests/test_entropy_models.py
+++ b/tests/test_entropy_models.py
@@ -261,26 +261,30 @@ class TestEntropyBottleneck:
         eb.update()
         s = eb.compress(x)
         x2 = eb.decompress(s, x.size()[2:])
+        means = eb._get_medians()
 
-        assert torch.allclose(torch.round(x), x2)
+        assert torch.allclose(torch.round(x - means) + means, x2)
 
     def test_compression_ND(self):
         eb = EntropyBottleneck(128)
         eb.update()
+
         # Test 0D
         x = torch.rand(1, 128)
         s = eb.compress(x)
         x2 = eb.decompress(s, [])
+        means = eb._get_medians().reshape(128)
 
-        assert torch.allclose(torch.round(x), x2)
+        assert torch.allclose(torch.round(x - means) + means, x2)
 
         # Test from 1 to 5 dimensions
         for i in range(1, 6):
             x = torch.rand(1, 128, *([4] * i))
             s = eb.compress(x)
             x2 = eb.decompress(s, x.size()[2:])
+            means = eb._get_medians().reshape(128, *([1] * i))
 
-            assert torch.allclose(torch.round(x), x2)
+            assert torch.allclose(torch.round(x - means) + means, x2)
 
 
 class TestGaussianConditional:


### PR DESCRIPTION
This method completes in <1 second and reduces aux_loss to <0.01.

This makes the aux_loss optimization during training unnecessary.

Another alternative would be to run the following post-training:
```python
while aux_loss > 0.1:
    aux_loss = model.aux_loss()
    aux_loss.backward()
    aux_optimizer.step()
    aux_optimizer.zero_grad()
```
...but since we do not manage aux_loss learning rates, the bisection search method might converge better.

**Note:** I haven't yet tested this extensively, so there might be some rough edges.