### PR TITLE
feat(models): add Checkerboard and ELIC

### DIFF
--- a/compressai/latent_codecs/__init__.py
+++ b/compressai/latent_codecs/__init__.py
@@ -28,6 +28,7 @@
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from .base import LatentCodec
+from .checkerboard import CheckerboardLatentCodec
 from .entropy_bottleneck import EntropyBottleneckLatentCodec
 from .gain import GainHyperLatentCodec, GainHyperpriorLatentCodec
 from .gaussian_conditional import GaussianConditionalLatentCodec
@@ -37,6 +38,7 @@ from .rasterscan import RasterScanLatentCodec
 
 __all__ = [
     "LatentCodec",
+    "CheckerboardLatentCodec",
     "EntropyBottleneckLatentCodec",
     "GainHyperLatentCodec",
     "GainHyperpriorLatentCodec",

--- a/compressai/latent_codecs/__init__.py
+++ b/compressai/latent_codecs/__init__.py
@@ -28,6 +28,7 @@
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from .base import LatentCodec
+from .channel_groups import ChannelGroupsLatentCodec
 from .checkerboard import CheckerboardLatentCodec
 from .entropy_bottleneck import EntropyBottleneckLatentCodec
 from .gain import GainHyperLatentCodec, GainHyperpriorLatentCodec
@@ -38,6 +39,7 @@ from .rasterscan import RasterScanLatentCodec
 
 __all__ = [
     "LatentCodec",
+    "ChannelGroupsLatentCodec",
     "CheckerboardLatentCodec",
     "EntropyBottleneckLatentCodec",
     "GainHyperLatentCodec",

--- a/compressai/latent_codecs/channel_groups.py
+++ b/compressai/latent_codecs/channel_groups.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2021-2022, InterDigital Communications, Inc
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted (subject to the limitations in the disclaimer
+# below) provided that the following conditions are met:
+
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of InterDigital Communications, Inc nor the names of its
+#   contributors may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+
+# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+# THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+# NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from itertools import accumulate
+from typing import Any, Dict, List, Mapping, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+from torch import Tensor
+
+from compressai.registry import register_module
+
+from .base import LatentCodec
+
+__all__ = [
+    "ChannelGroupsLatentCodec",
+]
+
+
+@register_module("ChannelGroupsLatentCodec")
+class ChannelGroupsLatentCodec(LatentCodec):
+    """Reconstructs groups of channels using previously decoded groups.
+
+    Context model from [Minnen2020] and [He2022].
+    Also known as a "channel-conditional" (CC) entropy model.
+
+    See :py:class:`~compressai.models.sensetime.Cheng2020AnchorElic`
+    for example usage.
+
+    [Minnen2020]: `"Channel-wise Autoregressive Entropy Models for
+    Learned Image Compression" <https://arxiv.org/abs/2007.08739>`_, by
+    David Minnen, and Saurabh Singh, ICIP 2020.
+
+    [He2022]: `"ELIC: Efficient Learned Image Compression with
+    Unevenly Grouped Space-Channel Contextual Adaptive Coding"
+    <https://arxiv.org/abs/2203.10886>`_, by Dailan He, Ziming Yang,
+    Weikun Peng, Rui Ma, Hongwei Qin, and Yan Wang, CVPR 2022.
+    """
+
+    latent_codec: Mapping[str, LatentCodec]
+
+    channel_context: Mapping[str, nn.Module]
+
+    def __init__(
+        self,
+        latent_codec: Optional[Mapping[str, LatentCodec]] = None,
+        channel_context: Optional[Mapping[str, nn.Module]] = None,
+        *,
+        groups: List[int],
+        **kwargs,
+    ):
+        super().__init__()
+        self._kwargs = kwargs
+        self.groups = list(groups)
+        self.groups_acc = list(accumulate(self.groups, initial=0))
+        self.channel_context = nn.ModuleDict(channel_context)
+        self.latent_codec = nn.ModuleDict(latent_codec)
+
+    def forward(self, y: Tensor, side_params: Tensor) -> Dict[str, Any]:
+        y_ = torch.split(y, self.groups, dim=1)
+        y_out_ = [{}] * len(self.groups)
+        y_hat_ = [Tensor()] * len(self.groups)
+        y_likelihoods_ = [Tensor()] * len(self.groups)
+
+        for k in range(len(self.groups)):
+            y_hat_prev = torch.cat(y_hat_[:k], dim=1) if k > 0 else Tensor()
+            params = self._get_ctx_params(k, side_params, y_hat_prev)
+            y_out_[k] = self.latent_codec[f"y{k}"](y_[k], params)
+            y_hat_[k] = y_out_[k]["y_hat"]
+            y_likelihoods_[k] = y_out_[k]["likelihoods"]["y"]
+
+        y_hat = torch.cat(y_hat_, dim=1)
+        y_likelihoods = torch.cat(y_likelihoods_, dim=1)
+
+        return {
+            "likelihoods": {
+                "y": y_likelihoods,
+            },
+            "y_hat": y_hat,
+        }
+
+    def compress(self, y: Tensor, side_params: Tensor) -> Dict[str, Any]:
+        y_ = torch.split(y, self.groups, dim=1)
+        y_out_ = [{}] * len(self.groups)
+        y_hat = torch.zeros_like(y)
+
+        for k in range(len(self.groups)):
+            y_hat_prev = y_hat[:, : self.groups_acc[k]]
+            params = self._get_ctx_params(k, side_params, y_hat_prev)
+            y_out_[k] = self.latent_codec[f"y{k}"].compress(y_[k], params)
+            y_hat[:, self.groups_acc[k] : self.groups_acc[k + 1]] = y_out_[k]["y_hat"]
+
+        y_strings_groups = [y_out["strings"] for y_out in y_out_]
+        assert all(len(y_strings_groups[0]) == len(ss) for ss in y_strings_groups)
+
+        return {
+            "strings": [s for ss in y_strings_groups for s in ss],
+            "shape": [y_out["shape"] for y_out in y_out_],
+            "y_hat": y_hat,
+        }
+
+    def decompress(
+        self,
+        strings: List[List[bytes]],
+        shape: List[Tuple[int, ...]],
+        side_params: Tensor,
+    ) -> Dict[str, Any]:
+        n = len(strings[0])
+        assert all(len(ss) == n for ss in strings)
+        strings_per_group = len(strings) // len(self.groups)
+
+        y_out_ = [{}] * len(self.groups)
+        y_shape = (sum(s[0] for s in shape), *shape[0][1:])
+        y_hat = torch.zeros((n, *y_shape), device=side_params.device)
+
+        for k in range(len(self.groups)):
+            y_hat_prev = y_hat[:, : self.groups_acc[k]]
+            params = self._get_ctx_params(k, side_params, y_hat_prev)
+            y_strings_k = strings[strings_per_group * k : strings_per_group * (k + 1)]
+            y_out_[k] = self.latent_codec[f"y{k}"].decompress(
+                y_strings_k, shape[k], params
+            )
+            y_hat[:, self.groups_acc[k] : self.groups_acc[k + 1]] = y_out_[k]["y_hat"]
+
+        return {
+            "y_hat": y_hat,
+        }
+
+    def _get_ctx_params(
+        self, k: int, side_params: Tensor, y_hat_prev: Tensor
+    ) -> Tensor:
+        if k == 0:
+            return side_params
+        params_ch = self.channel_context[f"y{k}"](y_hat_prev)
+        return torch.cat([side_params, params_ch], dim=1)

--- a/compressai/latent_codecs/channel_groups.py
+++ b/compressai/latent_codecs/channel_groups.py
@@ -51,7 +51,7 @@ class ChannelGroupsLatentCodec(LatentCodec):
     Context model from [Minnen2020] and [He2022].
     Also known as a "channel-conditional" (CC) entropy model.
 
-    See :py:class:`~compressai.models.sensetime.Cheng2020AnchorElic`
+    See :py:class:`~compressai.models.sensetime.Elic2022Official`
     for example usage.
 
     [Minnen2020]: `"Channel-wise Autoregressive Entropy Models for

--- a/compressai/latent_codecs/channel_groups.py
+++ b/compressai/latent_codecs/channel_groups.py
@@ -131,6 +131,7 @@ class ChannelGroupsLatentCodec(LatentCodec):
         strings: List[List[bytes]],
         shape: List[Tuple[int, ...]],
         side_params: Tensor,
+        **kwargs,
     ) -> Dict[str, Any]:
         n = len(strings[0])
         assert all(len(ss) == n for ss in strings)

--- a/compressai/latent_codecs/channel_groups.py
+++ b/compressai/latent_codecs/channel_groups.py
@@ -83,6 +83,9 @@ class ChannelGroupsLatentCodec(LatentCodec):
         self.channel_context = nn.ModuleDict(channel_context)
         self.latent_codec = nn.ModuleDict(latent_codec)
 
+    def __getitem__(self, key: str) -> LatentCodec:
+        return self.latent_codec[key]
+
     def forward(self, y: Tensor, side_params: Tensor) -> Dict[str, Any]:
         y_ = torch.split(y, self.groups, dim=1)
         y_out_ = [{}] * len(self.groups)

--- a/compressai/latent_codecs/channel_groups.py
+++ b/compressai/latent_codecs/channel_groups.py
@@ -169,4 +169,4 @@ class ChannelGroupsLatentCodec(LatentCodec):
         if k == 0:
             return side_params
         ch_ctx_params = self.channel_context[f"y{k}"](self.merge_y(*y_hat_[:k]))
-        return self.merge_params(side_params, ch_ctx_params)
+        return self.merge_params(ch_ctx_params, side_params)

--- a/compressai/latent_codecs/checkerboard.py
+++ b/compressai/latent_codecs/checkerboard.py
@@ -67,32 +67,32 @@ class CheckerboardLatentCodec(LatentCodec):
 
         0. Input:
 
-        ■ ■ ■ ■
-        ■ ■ ■ ■
-        ■ ■ ■ ■
+        □ □ □ □
+        □ □ □ □
+        □ □ □ □
 
         1. Decode anchors:
 
-        ◌ ■ ◌ ■
-        ■ ◌ ■ ◌
-        ◌ ■ ◌ ■
+        ◌ □ ◌ □
+        □ ◌ □ ◌
+        ◌ □ ◌ □
 
         2. Decode non-anchors:
 
-        □ ◌ □ ◌
-        ◌ □ ◌ □
-        □ ◌ □ ◌
+        ■ ◌ ■ ◌
+        ◌ ■ ◌ ■
+        ■ ◌ ■ ◌
 
         3. End result:
 
-        □ □ □ □
-        □ □ □ □
-        □ □ □ □
+        ■ ■ ■ ■
+        ■ ■ ■ ■
+        ■ ■ ■ ■
 
         LEGEND:
-        □   decoded
+        ■   decoded
         ◌   currently decoding
-        ■   empty
+        □   empty
     """
 
     latent_codec: Mapping[str, LatentCodec]
@@ -216,9 +216,9 @@ class CheckerboardLatentCodec(LatentCodec):
 
         .. code-block:: none
 
-            □ ■ □ ■         □ □   ■ ■
-            ■ □ ■ □   --->  □ □   ■ ■
-            □ ■ □ ■         □ □   ■ ■
+            ■ □ ■ □         ■ ■   □ □
+            □ ■ □ ■   --->  ■ ■   □ □
+            ■ □ ■ □         ■ ■   □ □
         """
         n, c, h, w = y.shape
         y_ = y.new_zeros((2, n, c, h, w // 2))
@@ -233,9 +233,9 @@ class CheckerboardLatentCodec(LatentCodec):
 
         .. code-block:: none
 
-            □ □   ■ ■         □ ■ □ ■
-            □ □   ■ ■   --->  ■ □ ■ □
-            □ □   ■ ■         □ ■ □ ■
+            ■ ■   □ □         ■ □ ■ □
+            ■ ■   □ □   --->  □ ■ □ ■
+            ■ ■   □ □         ■ □ ■ □
         """
         num_chunks, n, c, h, w_half = y_.shape
         assert num_chunks == 2

--- a/compressai/latent_codecs/checkerboard.py
+++ b/compressai/latent_codecs/checkerboard.py
@@ -188,6 +188,8 @@ class CheckerboardLatentCodec(LatentCodec):
 
         for i in range(2):
             y_ctx_i = self.unembed(self.context_prediction(self.embed(y_hat_)))[i]
+            if i == 0:
+                y_ctx_i = self._mask(y_ctx_i, "all")
             ctx_params_i = self.entropy_parameters(self.merge(y_ctx_i, side_params_[i]))
             y_out = self.latent_codec["y"].compress(y_[i], ctx_params_i)
             y_hat_[i] = y_out["y_hat"]
@@ -219,6 +221,8 @@ class CheckerboardLatentCodec(LatentCodec):
 
         for i in range(2):
             y_ctx_i = self.unembed(self.context_prediction(self.embed(y_hat_)))[i]
+            if i == 0:
+                y_ctx_i = self._mask(y_ctx_i, "all")
             ctx_params_i = self.entropy_parameters(self.merge(y_ctx_i, side_params_[i]))
             y_out = self.latent_codec["y"].decompress(
                 [y_strings_[i]], shape=(h, w // 2), ctx_params=ctx_params_i

--- a/compressai/latent_codecs/checkerboard.py
+++ b/compressai/latent_codecs/checkerboard.py
@@ -27,7 +27,7 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import Any, Dict, List, Mapping, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -100,14 +100,22 @@ class CheckerboardLatentCodec(LatentCodec):
     entropy_parameters: nn.Module
     context_prediction: CheckerboardMaskedConv2d
 
-    def __init__(self, forward_method="twopass", **kwargs):
+    def __init__(
+        self,
+        latent_codec: Optional[Mapping[str, LatentCodec]] = None,
+        entropy_parameters: Optional[nn.Module] = None,
+        context_prediction: Optional[nn.Module] = None,
+        forward_method="twopass",
+        **kwargs,
+    ):
         super().__init__()
         self._kwargs = kwargs
         self.forward_method = forward_method
-        self._setdefault("entropy_parameters", nn.Identity)
-        self._setdefault("context_prediction", nn.Identity)
+        self.entropy_parameters = entropy_parameters or nn.Identity()
+        self.context_prediction = context_prediction or nn.Identity()
         self._set_group_defaults(
             "latent_codec",
+            latent_codec,
             defaults={
                 "y": lambda: GaussianConditionalLatentCodec(quantizer="ste"),
             },

--- a/compressai/latent_codecs/checkerboard.py
+++ b/compressai/latent_codecs/checkerboard.py
@@ -154,7 +154,7 @@ class CheckerboardLatentCodec(LatentCodec):
         ctx_params = self.entropy_parameters(self.merge(y_ctx, side_params))
         ctx_params = self.latent_codec["y"].entropy_parameters(ctx_params)
         ctx_params = self._keep_only(ctx_params, "anchor")  # Probably not needed.
-        _, means_hat = ctx_params.chunk(2, 1)
+        _, means_hat = self.latent_codec["y"]._chunk(ctx_params)
         y_hat_anchors = quantize_ste(y - means_hat) + means_hat
         y_hat_anchors = self._keep_only(y_hat_anchors, "anchor")
 

--- a/compressai/latent_codecs/checkerboard.py
+++ b/compressai/latent_codecs/checkerboard.py
@@ -174,11 +174,10 @@ class CheckerboardLatentCodec(LatentCodec):
             "y_hat": y_hat,
         }
 
+    @torch.no_grad()
     def _y_ctx_zero(self, y):
-        """Create a zero tensor of the required shape."""
-        y_ctx = self.context_prediction(y).detach()
-        y_ctx[:] = 0
-        return y_ctx
+        """Create a zero tensor with correct shape for y_ctx."""
+        return self._mask(self.context_prediction(y).detach(), "all")
 
     def compress(self, y: Tensor, side_params: Tensor) -> Dict[str, Any]:
         n, c, h, w = y.shape

--- a/compressai/latent_codecs/checkerboard.py
+++ b/compressai/latent_codecs/checkerboard.py
@@ -53,6 +53,9 @@ class CheckerboardLatentCodec(LatentCodec):
 
     Checkerboard context model introduced in [He2021].
 
+    See :py:class:`~compressai.models.sensetime.Cheng2020AnchorCheckerboard`
+    for example usage.
+
     - `forward_method="one_pass"` is fastest, but does not use
       quantization based on the intermediate means.
     - `forward_method="two_pass"` is slightly slower, but accurately

--- a/compressai/latent_codecs/checkerboard.py
+++ b/compressai/latent_codecs/checkerboard.py
@@ -1,0 +1,217 @@
+# Copyright (c) 2021-2022, InterDigital Communications, Inc
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted (subject to the limitations in the disclaimer
+# below) provided that the following conditions are met:
+
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of InterDigital Communications, Inc nor the names of its
+#   contributors may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+
+# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+# THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+# NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from typing import Any, Dict, List, Mapping, Tuple
+
+import torch
+import torch.nn as nn
+
+from torch import Tensor
+
+from compressai.entropy_models import EntropyModel
+from compressai.layers import CheckerboardMaskedConv2d
+from compressai.registry import register_module
+
+from .base import LatentCodec
+from .gaussian_conditional import GaussianConditionalLatentCodec
+
+__all__ = [
+    "CheckerboardLatentCodec",
+]
+
+
+@register_module("CheckerboardLatentCodec")
+class CheckerboardLatentCodec(LatentCodec):
+    """Reconstructs latent using 2-pass context model with checkerboard anchors.
+
+    Checkerboard context model introduced in [He2021].
+
+    [He2021]: `"Checkerboard Context Model for Efficient Learned Image
+    Compression" <https://arxiv.org/abs/2103.15306>`_, by Dailan He,
+    Yaoyan Zheng, Baocheng Sun, Yan Wang, and Hongwei Qin, CVPR 2021.
+
+    .. warning:: This implementation assumes that ``entropy_parameters``
+       is a pointwise function, e.g., a composition of 1x1 convs and
+       pointwise nonlinearities.
+
+    .. note:: This implementation uses uniform noise for training quantization.
+
+    .. code-block:: none
+
+        0. Input:
+
+        ■ ■ ■ ■
+        ■ ■ ■ ■
+        ■ ■ ■ ■
+
+        1. Decode anchors:
+
+        ◌ ■ ◌ ■
+        ■ ◌ ■ ◌
+        ◌ ■ ◌ ■
+
+        2. Decode non-anchors:
+
+        □ ◌ □ ◌
+        ◌ □ ◌ □
+        □ ◌ □ ◌
+
+        3. End result:
+
+        □ □ □ □
+        □ □ □ □
+        □ □ □ □
+
+        LEGEND:
+        □   decoded
+        ◌   currently decoding
+        ■   empty
+    """
+
+    latent_codec: Mapping[str, LatentCodec]
+
+    entropy_parameters: nn.Module
+    context_prediction: CheckerboardMaskedConv2d
+
+    def __init__(self, **kwargs):
+        super().__init__()
+        self._kwargs = kwargs
+        self._setdefault("entropy_parameters", nn.Identity)
+        self._setdefault("context_prediction", nn.Identity)
+        self._set_group_defaults(
+            "latent_codec",
+            defaults={
+                "y": GaussianConditionalLatentCodec,
+            },
+            save_direct=True,
+        )
+
+    def forward(self, y: Tensor, side_params: Tensor) -> Dict[str, Any]:
+        y_hat = self.quantize(y)
+        ctx_params = self.entropy_parameters(
+            self.merge(side_params, self.context_prediction(y_hat))
+        )
+        y_out = self.latent_codec["y"](y, ctx_params)
+        return {
+            "likelihoods": {
+                "y": y_out["likelihoods"]["y"],
+            },
+            "y_hat": y_hat,
+        }
+
+    def compress(self, y: Tensor, side_params: Tensor) -> Dict[str, Any]:
+        n, c, h, w = y.shape
+        y_hat_ = side_params.new_zeros((2, n, c, h, w // 2))
+        side_params_ = self.unembed(side_params)
+        y_ = self.unembed(y)
+        y_strings_ = [None] * 2
+
+        for i in range(2):
+            y_ctx_i = self.unembed(self.context_prediction(self.embed(y_hat_)))[i]
+            ctx_params_i = self.entropy_parameters(self.merge(side_params_[i], y_ctx_i))
+            y_out = self.latent_codec["y"].compress(y_[i], ctx_params_i)
+            y_hat_[i] = y_out["y_hat"]
+            [y_strings_[i]] = y_out["strings"]
+
+        y_hat = self.embed(y_hat_)
+
+        return {
+            "strings": y_strings_,
+            "shape": y_hat.shape[1:],
+            "y_hat": y_hat,
+        }
+
+    def decompress(
+        self, strings: List[List[bytes]], shape: Tuple[int, ...], side_params: Tensor
+    ) -> Dict[str, Any]:
+        y_strings_ = strings
+        n = len(y_strings_[0])
+        assert len(y_strings_) == 2
+        assert all(len(x) == n for x in y_strings_)
+
+        c, h, w = shape
+        y_hat_ = side_params.new_zeros((2, n, c, h, w // 2))
+        side_params_ = self.unembed(side_params)
+
+        for i in range(2):
+            y_ctx_i = self.unembed(self.context_prediction(self.embed(y_hat_)))[i]
+            ctx_params_i = self.entropy_parameters(self.merge(side_params_[i], y_ctx_i))
+            y_out = self.latent_codec["y"].decompress(
+                [y_strings_[i]], shape=(h, w // 2), ctx_params=ctx_params_i
+            )
+            y_hat_[i] = y_out["y_hat"]
+
+        y_hat = self.embed(y_hat_)
+
+        return {
+            "y_hat": y_hat,
+        }
+
+    def unembed(self, y: Tensor) -> Tensor:
+        """Separate single tensor into two even/odd checkerboard chunks.
+
+        .. code-block:: none
+
+            □ ■ □ ■         □ □   ■ ■
+            ■ □ ■ □   --->  □ □   ■ ■
+            □ ■ □ ■         □ □   ■ ■
+        """
+        n, c, h, w = y.shape
+        y_ = y.new_zeros((2, n, c, h, w // 2))
+        y_[0, ..., 0::2, :] = y[..., 0::2, 0::2]
+        y_[0, ..., 1::2, :] = y[..., 1::2, 1::2]
+        y_[1, ..., 0::2, :] = y[..., 0::2, 1::2]
+        y_[1, ..., 1::2, :] = y[..., 1::2, 0::2]
+        return y_
+
+    def embed(self, y_: Tensor) -> Tensor:
+        """Combine two even/odd checkerboard chunks into single tensor.
+
+        .. code-block:: none
+
+            □ □   ■ ■         □ ■ □ ■
+            □ □   ■ ■   --->  ■ □ ■ □
+            □ □   ■ ■         □ ■ □ ■
+        """
+        num_chunks, n, c, h, w_half = y_.shape
+        assert num_chunks == 2
+        y = y_.new_zeros((n, c, h, w_half * 2))
+        y[..., 0::2, 0::2] = y_[0, ..., 0::2, :]
+        y[..., 1::2, 1::2] = y_[0, ..., 1::2, :]
+        y[..., 0::2, 1::2] = y_[1, ..., 0::2, :]
+        y[..., 1::2, 0::2] = y_[1, ..., 1::2, :]
+        return y
+
+    def merge(self, *args):
+        return torch.cat(args, dim=1)
+
+    def quantize(self, y: Tensor) -> Tensor:
+        mode = "noise" if self.training else "dequantize"
+        y_hat = EntropyModel.quantize(None, y, mode)
+        return y_hat

--- a/compressai/latent_codecs/checkerboard.py
+++ b/compressai/latent_codecs/checkerboard.py
@@ -186,7 +186,11 @@ class CheckerboardLatentCodec(LatentCodec):
         }
 
     def decompress(
-        self, strings: List[List[bytes]], shape: Tuple[int, ...], side_params: Tensor
+        self,
+        strings: List[List[bytes]],
+        shape: Tuple[int, ...],
+        side_params: Tensor,
+        **kwargs,
     ) -> Dict[str, Any]:
         y_strings_ = strings
         n = len(y_strings_[0])

--- a/compressai/latent_codecs/checkerboard.py
+++ b/compressai/latent_codecs/checkerboard.py
@@ -253,7 +253,8 @@ class CheckerboardLatentCodec(LatentCodec):
     @torch.no_grad()
     def _y_ctx_zero(self, y):
         """Create a zero tensor with correct shape for y_ctx."""
-        return self._mask(self.context_prediction(y).detach(), "all")
+        y_ctx_meta = self.context_prediction(y.to("meta"))
+        return y.new_zeros(y_ctx_meta.shape)
 
     def compress(self, y: Tensor, side_params: Tensor) -> Dict[str, Any]:
         n, c, h, w = y.shape

--- a/compressai/latent_codecs/checkerboard.py
+++ b/compressai/latent_codecs/checkerboard.py
@@ -129,8 +129,14 @@ class CheckerboardLatentCodec(LatentCodec):
         return self.latent_codec[key]
 
     def forward(self, y: Tensor, side_params: Tensor) -> Dict[str, Any]:
+        if self.forward_method == "onepass":
+            return self._forward_onepass(y, side_params)
         if self.forward_method == "twopass":
             return self._forward_twopass(y, side_params)
+        raise ValueError(f"Unknown forward method: {self.forward_method}")
+
+    def _forward_onepass(self, y: Tensor, side_params: Tensor) -> Dict[str, Any]:
+        """Fast estimation with single pass of the context model."""
         y_hat = self.quantize(y)
         y_ctx = self._mask_anchor(self.context_prediction(y_hat))
         ctx_params = self.entropy_parameters(self.merge(y_ctx, side_params))

--- a/compressai/latent_codecs/checkerboard.py
+++ b/compressai/latent_codecs/checkerboard.py
@@ -122,6 +122,9 @@ class CheckerboardLatentCodec(LatentCodec):
             save_direct=True,
         )
 
+    def __getitem__(self, key: str) -> LatentCodec:
+        return self.latent_codec[key]
+
     def forward(self, y: Tensor, side_params: Tensor) -> Dict[str, Any]:
         if self.forward_method == "twopass":
             return self._forward_twopass(y, side_params)

--- a/compressai/latent_codecs/entropy_bottleneck.py
+++ b/compressai/latent_codecs/entropy_bottleneck.py
@@ -80,7 +80,7 @@ class EntropyBottleneckLatentCodec(LatentCodec):
         return {"strings": [y_strings], "shape": shape, "y_hat": y_hat}
 
     def decompress(
-        self, strings: List[List[bytes]], shape: Tuple[int, int]
+        self, strings: List[List[bytes]], shape: Tuple[int, int], **kwargs
     ) -> Dict[str, Any]:
         (y_strings,) = strings
         y_hat = self.entropy_bottleneck.decompress(y_strings, shape)

--- a/compressai/latent_codecs/gain/hyper.py
+++ b/compressai/latent_codecs/gain/hyper.py
@@ -102,7 +102,11 @@ class GainHyperLatentCodec(LatentCodec):
         return {"strings": [z_strings], "shape": shape, "params": params}
 
     def decompress(
-        self, strings: List[List[bytes]], shape: Tuple[int, int], gain_inv: Tensor
+        self,
+        strings: List[List[bytes]],
+        shape: Tuple[int, int],
+        gain_inv: Tensor,
+        **kwargs,
     ) -> Dict[str, Any]:
         (z_strings,) = strings
         z_hat = self.entropy_bottleneck.decompress(z_strings, shape)

--- a/compressai/latent_codecs/gain/hyperprior.py
+++ b/compressai/latent_codecs/gain/hyperprior.py
@@ -110,6 +110,9 @@ class GainHyperpriorLatentCodec(LatentCodec):
             save_direct=True,
         )
 
+    def __getitem__(self, key: str) -> LatentCodec:
+        return self.latent_codec[key]
+
     def forward(
         self,
         y: Tensor,

--- a/compressai/latent_codecs/gain/hyperprior.py
+++ b/compressai/latent_codecs/gain/hyperprior.py
@@ -152,6 +152,7 @@ class GainHyperpriorLatentCodec(LatentCodec):
         shape: Dict[str, Tuple[int, ...]],
         y_gain_inv: Tensor,
         z_gain_inv: Tensor,
+        **kwargs,
     ) -> Dict[str, Any]:
         *y_strings_, z_strings = strings
         assert all(len(y_strings) == len(z_strings) for y_strings in y_strings_)

--- a/compressai/latent_codecs/gaussian_conditional.py
+++ b/compressai/latent_codecs/gaussian_conditional.py
@@ -85,6 +85,7 @@ class GaussianConditionalLatentCodec(LatentCodec):
         gaussian_conditional: Optional[GaussianConditional] = None,
         entropy_parameters: Optional[nn.Module] = None,
         quantizer: str = "noise",
+        chunks: Tuple[str] = ("scales", "means"),
         **kwargs,
     ):
         super().__init__()
@@ -93,10 +94,11 @@ class GaussianConditionalLatentCodec(LatentCodec):
             scale_table, **kwargs
         )
         self.entropy_parameters = entropy_parameters or nn.Identity()
+        self.chunks = tuple(chunks)
 
     def forward(self, y: Tensor, ctx_params: Tensor) -> Dict[str, Any]:
         gaussian_params = self.entropy_parameters(ctx_params)
-        scales_hat, means_hat = gaussian_params.chunk(2, 1)
+        scales_hat, means_hat = self._chunk(gaussian_params)
         y_hat, y_likelihoods = self.gaussian_conditional(y, scales_hat, means=means_hat)
         if self.quantizer == "ste":
             y_hat = quantize_ste(y - means_hat) + means_hat
@@ -104,7 +106,7 @@ class GaussianConditionalLatentCodec(LatentCodec):
 
     def compress(self, y: Tensor, ctx_params: Tensor) -> Dict[str, Any]:
         gaussian_params = self.entropy_parameters(ctx_params)
-        scales_hat, means_hat = gaussian_params.chunk(2, 1)
+        scales_hat, means_hat = self._chunk(gaussian_params)
         indexes = self.gaussian_conditional.build_indexes(scales_hat)
         y_strings = self.gaussian_conditional.compress(y, indexes, means_hat)
         y_hat = self.gaussian_conditional.decompress(
@@ -121,10 +123,22 @@ class GaussianConditionalLatentCodec(LatentCodec):
     ) -> Dict[str, Any]:
         (y_strings,) = strings
         gaussian_params = self.entropy_parameters(ctx_params)
-        scales_hat, means_hat = gaussian_params.chunk(2, 1)
+        scales_hat, means_hat = self._chunk(gaussian_params)
         indexes = self.gaussian_conditional.build_indexes(scales_hat)
         y_hat = self.gaussian_conditional.decompress(
             y_strings, indexes, means=means_hat
         )
         assert y_hat.shape[2:4] == shape
         return {"y_hat": y_hat}
+
+    def _chunk(self, params: Tensor) -> Tuple[Tensor, Tensor]:
+        scales, means = None, None
+        if self.chunks == ("scales",):
+            scales = params
+        if self.chunks == ("means",):
+            means = params
+        if self.chunks == ("scales", "means"):
+            scales, means = params.chunk(2, 1)
+        if self.chunks == ("means", "scales"):
+            means, scales = params.chunk(2, 1)
+        return scales, means

--- a/compressai/latent_codecs/gaussian_conditional.py
+++ b/compressai/latent_codecs/gaussian_conditional.py
@@ -113,7 +113,11 @@ class GaussianConditionalLatentCodec(LatentCodec):
         return {"strings": [y_strings], "shape": y.shape[2:4], "y_hat": y_hat}
 
     def decompress(
-        self, strings: List[List[bytes]], shape: Tuple[int, int], ctx_params: Tensor
+        self,
+        strings: List[List[bytes]],
+        shape: Tuple[int, int],
+        ctx_params: Tensor,
+        **kwargs,
     ) -> Dict[str, Any]:
         (y_strings,) = strings
         gaussian_params = self.entropy_parameters(ctx_params)

--- a/compressai/latent_codecs/hyper.py
+++ b/compressai/latent_codecs/hyper.py
@@ -96,7 +96,7 @@ class HyperLatentCodec(LatentCodec):
         return {"strings": [z_strings], "shape": shape, "params": params}
 
     def decompress(
-        self, strings: List[List[bytes]], shape: Tuple[int, int]
+        self, strings: List[List[bytes]], shape: Tuple[int, int], **kwargs
     ) -> Dict[str, Any]:
         (z_strings,) = strings
         z_hat = self.entropy_bottleneck.decompress(z_strings, shape)

--- a/compressai/latent_codecs/hyperprior.py
+++ b/compressai/latent_codecs/hyperprior.py
@@ -103,6 +103,9 @@ class HyperpriorLatentCodec(LatentCodec):
             save_direct=True,
         )
 
+    def __getitem__(self, key: str) -> LatentCodec:
+        return self.latent_codec[key]
+
     def forward(self, y: Tensor) -> Dict[str, Any]:
         hyper_out = self.latent_codec["hyper"](y)
         y_out = self.latent_codec["y"](y, hyper_out["params"])

--- a/compressai/latent_codecs/hyperprior.py
+++ b/compressai/latent_codecs/hyperprior.py
@@ -125,7 +125,7 @@ class HyperpriorLatentCodec(LatentCodec):
         }
 
     def decompress(
-        self, strings: List[List[bytes]], shape: Dict[str, Tuple[int, ...]]
+        self, strings: List[List[bytes]], shape: Dict[str, Tuple[int, ...]], **kwargs
     ) -> Dict[str, Any]:
         *y_strings_, z_strings = strings
         assert all(len(y_strings) == len(z_strings) for y_strings in y_strings_)

--- a/compressai/latent_codecs/rasterscan.py
+++ b/compressai/latent_codecs/rasterscan.py
@@ -137,7 +137,11 @@ class RasterScanLatentCodec(LatentCodec):
         return {"strings": [y_strings], "y_hat": y_hat.squeeze(0)}
 
     def decompress(
-        self, strings: List[List[bytes]], shape: Tuple[int, int], ctx_params: Tensor
+        self,
+        strings: List[List[bytes]],
+        shape: Tuple[int, int],
+        ctx_params: Tensor,
+        **kwargs,
     ) -> Dict[str, Any]:
         (y_strings,) = strings
         y_height, y_width = shape

--- a/compressai/layers/layers.py
+++ b/compressai/layers/layers.py
@@ -46,6 +46,7 @@ __all__ = [
     "ResidualBlock",
     "ResidualBlockUpsample",
     "ResidualBlockWithStride",
+    "conv1x1",
     "conv3x3",
     "subpel_conv3x3",
     "QReLU",

--- a/compressai/layers/layers.py
+++ b/compressai/layers/layers.py
@@ -79,7 +79,7 @@ class MaskedConv2d(nn.Conv2d):
 
     def forward(self, x: Tensor) -> Tensor:
         # TODO(begaintj): weight assigment is not supported by torchscript
-        self.weight.data *= self.mask
+        self.weight.data = self.weight.data * self.mask
         return super().forward(x)
 
 

--- a/compressai/layers/layers.py
+++ b/compressai/layers/layers.py
@@ -331,6 +331,7 @@ def sequential_channel_ramp(
     in_ch: int,
     out_ch: int,
     *,
+    min_ch: int = 0,
     num_layers: int = 3,
     interp: str = "linear",
     make_layer=None,
@@ -339,7 +340,9 @@ def sequential_channel_ramp(
     **layer_kwargs,
 ) -> nn.Module:
     """Interleave layers of gradually ramping channels with nonlinearities."""
-    channels = ramp(in_ch, out_ch, num_layers + 1, method=interp).floor().int().tolist()
+    channels = ramp(in_ch, out_ch, num_layers + 1, method=interp).floor().int()
+    channels[1:-1] = channels[1:-1].clip(min=min_ch)
+    channels = channels.tolist()
     layers = [
         module
         for ch_in, ch_out in zip(channels[:-1], channels[1:])

--- a/compressai/models/__init__.py
+++ b/compressai/models/__init__.py
@@ -29,4 +29,5 @@
 
 from .base import *
 from .google import *
+from .sensetime import *
 from .waseda import *

--- a/compressai/models/base.py
+++ b/compressai/models/base.py
@@ -200,8 +200,8 @@ class SimpleVAECompressionModel(CompressionModel):
         outputs = self.latent_codec.compress(y)
         return outputs
 
-    def decompress(self, strings, shape):
-        y_out = self.latent_codec.decompress(strings, shape)
+    def decompress(self, *args, **kwargs):
+        y_out = self.latent_codec.decompress(*args, **kwargs)
         y_hat = y_out["y_hat"]
         x_hat = self.g_s(y_hat).clamp_(0, 1)
         return {

--- a/compressai/models/base.py
+++ b/compressai/models/base.py
@@ -185,6 +185,9 @@ class SimpleVAECompressionModel(CompressionModel):
     g_s: nn.Module
     latent_codec: LatentCodec
 
+    def __getitem__(self, key: str) -> LatentCodec:
+        return self.latent_codec[key]
+
     def forward(self, x):
         y = self.g_a(x)
         y_out = self.latent_codec(y)

--- a/compressai/models/sensetime.py
+++ b/compressai/models/sensetime.py
@@ -27,9 +27,10 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from itertools import accumulate
-
+import torch
 import torch.nn as nn
+
+from torch import Tensor
 
 from compressai.entropy_models import EntropyBottleneck
 from compressai.latent_codecs import (
@@ -40,10 +41,12 @@ from compressai.latent_codecs import (
     HyperpriorLatentCodec,
 )
 from compressai.layers import (
+    AttentionBlock,
     CheckerboardMaskedConv2d,
     ResidualBlock,
     ResidualBlockUpsample,
     ResidualBlockWithStride,
+    conv1x1,
     conv3x3,
     sequential_channel_ramp,
     subpel_conv3x3,
@@ -51,10 +54,11 @@ from compressai.layers import (
 from compressai.registry import register_model
 
 from .base import SimpleVAECompressionModel
+from .utils import conv, deconv
 
 __all__ = [
     "Cheng2020AnchorCheckerboard",
-    "Cheng2020AnchorElic",
+    "Elic2022Official",
 ]
 
 
@@ -142,7 +146,7 @@ class Cheng2020AnchorCheckerboard(SimpleVAECompressionModel):
                         nn.Conv2d(N * 8 // 3, N * 6 // 3, 1),
                     ),
                     context_prediction=CheckerboardMaskedConv2d(
-                        N, 2 * N, kernel_size=5, padding=2, stride=1
+                        N, 2 * N, kernel_size=5, stride=1, padding=2
                     ),
                 ),
                 "hyper": HyperLatentCodec(
@@ -160,96 +164,101 @@ class Cheng2020AnchorCheckerboard(SimpleVAECompressionModel):
         return net
 
 
-@register_model("cheng2020-anchor-elic")
-class Cheng2020AnchorElic(SimpleVAECompressionModel):
-    """Cheng2020 anchor model with checkerboard context model.
+@register_model("elic2022-official")
+class Elic2022Official(SimpleVAECompressionModel):
+    """ELIC 2022; uneven channel groups with checkerboard spatial context.
 
-    Base transform model from [Cheng2020]. Context model from [He2022].
-
-    [Cheng2020]: `"Learned Image Compression with Discretized Gaussian
-    Mixture Likelihoods and Attention Modules"
-    <https://arxiv.org/abs/2001.01568>`_, by Zhengxue Cheng, Heming Sun,
-    Masaru Takeuchi, and Jiro Katto, CVPR 2020.
+    Context model from [He2022].
+    Based on modified attention model architecture from [Cheng2020].
 
     [He2022]: `"ELIC: Efficient Learned Image Compression with
     Unevenly Grouped Space-Channel Contextual Adaptive Coding"
     <https://arxiv.org/abs/2203.10886>`_, by Dailan He, Ziming Yang,
     Weikun Peng, Rui Ma, Hongwei Qin, and Yan Wang, CVPR 2022.
 
-    Uses residual blocks with small convolutions (3x3 and 1x1), and sub-pixel
-    convolutions for up-sampling.
+    [Cheng2020]: `"Learned Image Compression with Discretized Gaussian
+    Mixture Likelihoods and Attention Modules"
+    <https://arxiv.org/abs/2001.01568>`_, by Zhengxue Cheng, Heming Sun,
+    Masaru Takeuchi, and Jiro Katto, CVPR 2020.
 
     Args:
-        N (int): Number of channels
+        N (int): Number of main network channels
+        M (int): Number of latent space channels
         groups (list[int]): Number of channels in each channel group
     """
 
-    def __init__(self, N=192, groups=None, **kwargs):
+    def __init__(self, N=192, M=320, groups=None, **kwargs):
         super().__init__(**kwargs)
 
         if groups is None:
-            groups = [16, 16, 32, 64, 64]
+            groups = [16, 16, 32, 64, M - 128]
 
-        assert sum(groups) == N
         self.groups = list(groups)
-        self.groups_acc = list(accumulate(self.groups, initial=0))
+        assert sum(self.groups) == M
 
         self.g_a = nn.Sequential(
-            ResidualBlockWithStride(3, N, stride=2),
-            ResidualBlock(N, N),
-            ResidualBlockWithStride(N, N, stride=2),
-            ResidualBlock(N, N),
-            ResidualBlockWithStride(N, N, stride=2),
-            ResidualBlock(N, N),
-            conv3x3(N, N, stride=2),
+            conv(3, N, kernel_size=5, stride=2),
+            ResidualBottleneckBlock(N, N),
+            ResidualBottleneckBlock(N, N),
+            ResidualBottleneckBlock(N, N),
+            conv(N, N, kernel_size=5, stride=2),
+            ResidualBottleneckBlock(N, N),
+            ResidualBottleneckBlock(N, N),
+            ResidualBottleneckBlock(N, N),
+            AttentionBlock(N),
+            conv(N, N, kernel_size=5, stride=2),
+            ResidualBottleneckBlock(N, N),
+            ResidualBottleneckBlock(N, N),
+            ResidualBottleneckBlock(N, N),
+            conv(N, M, kernel_size=5, stride=2),
+            AttentionBlock(M),
         )
 
         self.g_s = nn.Sequential(
-            ResidualBlock(N, N),
-            ResidualBlockUpsample(N, N, 2),
-            ResidualBlock(N, N),
-            ResidualBlockUpsample(N, N, 2),
-            ResidualBlock(N, N),
-            ResidualBlockUpsample(N, N, 2),
-            ResidualBlock(N, N),
-            subpel_conv3x3(N, 3, 2),
+            AttentionBlock(M),
+            deconv(M, N, kernel_size=5, stride=2),
+            ResidualBottleneckBlock(N, N),
+            ResidualBottleneckBlock(N, N),
+            ResidualBottleneckBlock(N, N),
+            deconv(N, N, kernel_size=5, stride=2),
+            AttentionBlock(N),
+            ResidualBottleneckBlock(N, N),
+            ResidualBottleneckBlock(N, N),
+            ResidualBottleneckBlock(N, N),
+            deconv(N, N, kernel_size=5, stride=2),
+            ResidualBottleneckBlock(N, N),
+            ResidualBottleneckBlock(N, N),
+            ResidualBottleneckBlock(N, N),
+            deconv(N, 3, kernel_size=5, stride=2),
         )
 
         h_a = nn.Sequential(
-            conv3x3(N, N),
-            nn.LeakyReLU(inplace=True),
-            conv3x3(N, N),
-            nn.LeakyReLU(inplace=True),
-            conv3x3(N, N, stride=2),
-            nn.LeakyReLU(inplace=True),
-            conv3x3(N, N),
-            nn.LeakyReLU(inplace=True),
-            conv3x3(N, N, stride=2),
+            conv(M, N, kernel_size=3, stride=1),
+            nn.ReLU(inplace=True),
+            conv(N, N, kernel_size=5, stride=2),
+            nn.ReLU(inplace=True),
+            conv(N, N, kernel_size=5, stride=2),
         )
 
         h_s = nn.Sequential(
-            conv3x3(N, N),
-            nn.LeakyReLU(inplace=True),
-            subpel_conv3x3(N, N, 2),
-            nn.LeakyReLU(inplace=True),
-            conv3x3(N, N * 3 // 2),
-            nn.LeakyReLU(inplace=True),
-            subpel_conv3x3(N * 3 // 2, N * 3 // 2, 2),
-            nn.LeakyReLU(inplace=True),
-            conv3x3(N * 3 // 2, N * 2),
+            deconv(N, N, kernel_size=5, stride=2),
+            nn.ReLU(inplace=True),
+            deconv(N, N * 3 // 2, kernel_size=5, stride=2),
+            nn.ReLU(inplace=True),
+            deconv(N * 3 // 2, N * 2, kernel_size=3, stride=1),
         )
 
         # In [He2022], this is labeled "g_ch^(k)".
         channel_context = {
             f"y{k}": sequential_channel_ramp(
-                self.groups_acc[k],
+                sum(self.groups[:k]),
                 self.groups[k] * 2,
                 num_layers=3,
                 make_layer=nn.Conv2d,
                 make_act=lambda: nn.ReLU(inplace=True),
                 kernel_size=5,
-                padding=2,
                 stride=1,
+                padding=2,
             )
             for k in range(1, len(self.groups))
         }
@@ -260,8 +269,8 @@ class Cheng2020AnchorElic(SimpleVAECompressionModel):
                 self.groups[k],
                 self.groups[k] * 2,
                 kernel_size=5,
-                padding=2,
                 stride=1,
+                padding=2,
             )
             for k in range(len(self.groups))
         ]
@@ -269,14 +278,15 @@ class Cheng2020AnchorElic(SimpleVAECompressionModel):
         # In [He2022], this is labeled "Param Aggregation".
         param_aggregation = [
             sequential_channel_ramp(
-                N * 2 + self.groups[k] * (2 if k == 0 else 4),
+                # Input: spatial context, channel context, and hyper params.
+                self.groups[k] * 2 + (k > 0) * self.groups[k] * 2 + N * 2,
                 self.groups[k] * 2,
                 num_layers=3,
                 make_layer=nn.Conv2d,
                 make_act=lambda: nn.ReLU(inplace=True),
                 kernel_size=1,
-                padding=0,
                 stride=1,
+                padding=0,
             )
             for k in range(len(self.groups))
         ]
@@ -313,7 +323,50 @@ class Cheng2020AnchorElic(SimpleVAECompressionModel):
     @classmethod
     def from_state_dict(cls, state_dict):
         """Return a new model instance from `state_dict`."""
-        N = state_dict["g_a.0.conv1.weight"].size(0)
+        N = state_dict["g_a.0.weight"].size(0)
         net = cls(N)
         net.load_state_dict(state_dict)
         return net
+
+
+class ResidualBottleneckBlock(nn.Module):
+    """Residual bottleneck block.
+
+    Introduced by [He2016], this block sandwiches a 3x3 convolution
+    between two 1x1 convolutions which reduce and then restore the
+    number of channels. This reduces the number of parameters required.
+
+    [He2016]: `"Deep Residual Learning for Image Recognition"
+    <https://arxiv.org/abs/1512.03385>`_, by Kaiming He, Xiangyu Zhang,
+    Shaoqing Ren, and Jian Sun, CVPR 2016.
+
+    Args:
+        in_ch (int): Number of input channels
+        out_ch (int): Number of output channels
+    """
+
+    def __init__(self, in_ch: int, out_ch: int):
+        super().__init__()
+
+        mid_ch = min(in_ch, out_ch) // 2
+        self.conv1 = conv1x1(in_ch, mid_ch)
+        self.conv2 = conv3x3(mid_ch, mid_ch)
+        self.conv3 = conv1x1(mid_ch, out_ch)
+        self.relu = nn.ReLU(inplace=True)
+
+        if in_ch != out_ch:
+            self.skip = conv1x1(in_ch, out_ch)
+        else:
+            self.skip = None
+
+    def forward(self, x: Tensor) -> Tensor:
+        identity = x if self.skip is None else self.skip(x)
+
+        out = x
+        out = self.conv1(out)
+        out = self.relu(out)
+        out = self.conv2(out)
+        out = self.relu(out)
+        out = self.conv3(out)
+
+        return out + identity

--- a/compressai/models/sensetime.py
+++ b/compressai/models/sensetime.py
@@ -29,6 +29,7 @@
 
 import torch.nn as nn
 
+from compressai.entropy_models import EntropyBottleneck
 from compressai.latent_codecs import (
     CheckerboardLatentCodec,
     GaussianConditionalLatentCodec,
@@ -123,7 +124,6 @@ class Cheng2020AnchorCheckerboard(SimpleVAECompressionModel):
         )
 
         self.latent_codec = HyperpriorLatentCodec(
-            N,
             latent_codec={
                 "y": CheckerboardLatentCodec(
                     latent_codec={
@@ -140,7 +140,9 @@ class Cheng2020AnchorCheckerboard(SimpleVAECompressionModel):
                         N, 2 * N, kernel_size=5, padding=2, stride=1
                     ),
                 ),
-                "hyper": HyperLatentCodec(N, h_a=h_a, h_s=h_s),
+                "hyper": HyperLatentCodec(
+                    entropy_bottleneck=EntropyBottleneck(N), h_a=h_a, h_s=h_s
+                ),
             },
         )
 

--- a/compressai/models/sensetime.py
+++ b/compressai/models/sensetime.py
@@ -61,6 +61,7 @@ from .utils import conv, deconv
 __all__ = [
     "Cheng2020AnchorCheckerboard",
     "Elic2022Official",
+    "Elic2022Chandelier",
 ]
 
 

--- a/compressai/models/sensetime.py
+++ b/compressai/models/sensetime.py
@@ -551,26 +551,22 @@ class ResidualBottleneckBlock(nn.Module):
 
     def __init__(self, in_ch: int, out_ch: int):
         super().__init__()
-
         mid_ch = min(in_ch, out_ch) // 2
         self.conv1 = conv1x1(in_ch, mid_ch)
+        self.relu1 = nn.ReLU(inplace=True)
         self.conv2 = conv3x3(mid_ch, mid_ch)
+        self.relu2 = nn.ReLU(inplace=True)
         self.conv3 = conv1x1(mid_ch, out_ch)
-        self.relu = nn.ReLU(inplace=True)
-
-        if in_ch != out_ch:
-            self.skip = conv1x1(in_ch, out_ch)
-        else:
-            self.skip = None
+        self.skip = conv1x1(in_ch, out_ch) if in_ch != out_ch else nn.Identity()
 
     def forward(self, x: Tensor) -> Tensor:
-        identity = x if self.skip is None else self.skip(x)
+        identity = self.skip(x)
 
         out = x
         out = self.conv1(out)
-        out = self.relu(out)
+        out = self.relu1(out)
         out = self.conv2(out)
-        out = self.relu(out)
+        out = self.relu2(out)
         out = self.conv3(out)
 
         return out + identity

--- a/compressai/models/sensetime.py
+++ b/compressai/models/sensetime.py
@@ -152,7 +152,10 @@ class Cheng2020AnchorCheckerboard(SimpleVAECompressionModel):
                     ),
                 ),
                 "hyper": HyperLatentCodec(
-                    entropy_bottleneck=EntropyBottleneck(N), h_a=h_a, h_s=h_s
+                    entropy_bottleneck=EntropyBottleneck(N),
+                    h_a=h_a,
+                    h_s=h_s,
+                    quantizer="ste",
                 ),
             },
         )
@@ -319,7 +322,10 @@ class Elic2022Official(SimpleVAECompressionModel):
                 ),
                 # Side information branch containing z:
                 "hyper": HyperLatentCodec(
-                    entropy_bottleneck=EntropyBottleneck(N), h_a=h_a, h_s=h_s
+                    entropy_bottleneck=EntropyBottleneck(N),
+                    h_a=h_a,
+                    h_s=h_s,
+                    quantizer="ste",
                 ),
             },
         )
@@ -503,7 +509,10 @@ class Elic2022Chandelier(SimpleVAECompressionModel):
                 ),
                 # Side information branch containing z:
                 "hyper": HyperLatentCodec(
-                    entropy_bottleneck=EntropyBottleneck(N), h_a=h_a, h_s=h_s
+                    entropy_bottleneck=EntropyBottleneck(N),
+                    h_a=h_a,
+                    h_s=h_s,
+                    quantizer="ste",
                 ),
             },
         )

--- a/compressai/models/sensetime.py
+++ b/compressai/models/sensetime.py
@@ -27,29 +27,34 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from itertools import accumulate
+
 import torch.nn as nn
 
 from compressai.entropy_models import EntropyBottleneck
 from compressai.latent_codecs import (
+    ChannelGroupsLatentCodec,
     CheckerboardLatentCodec,
     GaussianConditionalLatentCodec,
     HyperLatentCodec,
     HyperpriorLatentCodec,
 )
 from compressai.layers import (
+    CheckerboardMaskedConv2d,
     ResidualBlock,
     ResidualBlockUpsample,
     ResidualBlockWithStride,
     conv3x3,
+    sequential_channel_ramp,
     subpel_conv3x3,
 )
-from compressai.layers.layers import CheckerboardMaskedConv2d
 from compressai.registry import register_model
 
 from .base import SimpleVAECompressionModel
 
 __all__ = [
     "Cheng2020AnchorCheckerboard",
+    "Cheng2020AnchorElic",
 ]
 
 
@@ -139,6 +144,143 @@ class Cheng2020AnchorCheckerboard(SimpleVAECompressionModel):
                     context_prediction=CheckerboardMaskedConv2d(
                         N, 2 * N, kernel_size=5, padding=2, stride=1
                     ),
+                ),
+                "hyper": HyperLatentCodec(
+                    entropy_bottleneck=EntropyBottleneck(N), h_a=h_a, h_s=h_s
+                ),
+            },
+        )
+
+    @classmethod
+    def from_state_dict(cls, state_dict):
+        """Return a new model instance from `state_dict`."""
+        N = state_dict["g_a.0.conv1.weight"].size(0)
+        net = cls(N)
+        net.load_state_dict(state_dict)
+        return net
+
+
+@register_model("cheng2020-anchor-elic")
+class Cheng2020AnchorElic(SimpleVAECompressionModel):
+    """Cheng2020 anchor model with checkerboard context model.
+
+    Base transform model from [Cheng2020]. Context model from [He2022].
+
+    [Cheng2020]: `"Learned Image Compression with Discretized Gaussian
+    Mixture Likelihoods and Attention Modules"
+    <https://arxiv.org/abs/2001.01568>`_, by Zhengxue Cheng, Heming Sun,
+    Masaru Takeuchi, and Jiro Katto, CVPR 2020.
+
+    [He2022]: `"ELIC: Efficient Learned Image Compression with
+    Unevenly Grouped Space-Channel Contextual Adaptive Coding"
+    <https://arxiv.org/abs/2203.10886>`_, by Dailan He, Ziming Yang,
+    Weikun Peng, Rui Ma, Hongwei Qin, and Yan Wang, CVPR 2022.
+
+    Uses residual blocks with small convolutions (3x3 and 1x1), and sub-pixel
+    convolutions for up-sampling.
+
+    Args:
+        N (int): Number of channels
+        groups (list[int]): Number of channels in each channel group
+    """
+
+    def __init__(self, N=192, groups=None, **kwargs):
+        super().__init__(**kwargs)
+
+        if groups is None:
+            groups = [16, 16, 32, 64, 64]
+
+        assert sum(groups) == N
+        self.groups = list(groups)
+        self.groups_acc = list(accumulate(self.groups, initial=0))
+
+        self.g_a = nn.Sequential(
+            ResidualBlockWithStride(3, N, stride=2),
+            ResidualBlock(N, N),
+            ResidualBlockWithStride(N, N, stride=2),
+            ResidualBlock(N, N),
+            ResidualBlockWithStride(N, N, stride=2),
+            ResidualBlock(N, N),
+            conv3x3(N, N, stride=2),
+        )
+
+        self.g_s = nn.Sequential(
+            ResidualBlock(N, N),
+            ResidualBlockUpsample(N, N, 2),
+            ResidualBlock(N, N),
+            ResidualBlockUpsample(N, N, 2),
+            ResidualBlock(N, N),
+            ResidualBlockUpsample(N, N, 2),
+            ResidualBlock(N, N),
+            subpel_conv3x3(N, 3, 2),
+        )
+
+        h_a = nn.Sequential(
+            conv3x3(N, N),
+            nn.LeakyReLU(inplace=True),
+            conv3x3(N, N),
+            nn.LeakyReLU(inplace=True),
+            conv3x3(N, N, stride=2),
+            nn.LeakyReLU(inplace=True),
+            conv3x3(N, N),
+            nn.LeakyReLU(inplace=True),
+            conv3x3(N, N, stride=2),
+        )
+
+        h_s = nn.Sequential(
+            conv3x3(N, N),
+            nn.LeakyReLU(inplace=True),
+            subpel_conv3x3(N, N, 2),
+            nn.LeakyReLU(inplace=True),
+            conv3x3(N, N * 3 // 2),
+            nn.LeakyReLU(inplace=True),
+            subpel_conv3x3(N * 3 // 2, N * 3 // 2, 2),
+            nn.LeakyReLU(inplace=True),
+            conv3x3(N * 3 // 2, N * 2),
+        )
+
+        self.latent_codec = HyperpriorLatentCodec(
+            latent_codec={
+                "y": ChannelGroupsLatentCodec(
+                    groups=self.groups,
+                    channel_context={
+                        f"y{k}": sequential_channel_ramp(
+                            self.groups_acc[k],
+                            self.groups[k] * 2,
+                            num_layers=3,
+                            make_layer=nn.Conv2d,
+                            make_act=lambda: nn.ReLU(inplace=True),
+                            kernel_size=5,
+                            padding=2,
+                            stride=1,
+                        )
+                        for k in range(1, len(self.groups))
+                    },
+                    latent_codec={
+                        f"y{k}": CheckerboardLatentCodec(
+                            latent_codec={
+                                "y": GaussianConditionalLatentCodec(quantizer="ste"),
+                            },
+                            entropy_parameters=sequential_channel_ramp(
+                                N * 2 + self.groups[k] * (2 if k == 0 else 4),
+                                self.groups[k] * 2,
+                                num_layers=3,
+                                make_layer=nn.Conv2d,
+                                make_act=lambda: nn.ReLU(inplace=True),
+                                kernel_size=1,
+                                padding=0,
+                                stride=1,
+                            ),
+                            context_prediction=CheckerboardMaskedConv2d(
+                                self.groups[k],
+                                self.groups[k] * 2,
+                                kernel_size=5,
+                                padding=2,
+                                stride=1,
+                            ),
+                        )
+                        for k in range(len(self.groups))
+                    },
                 ),
                 "hyper": HyperLatentCodec(
                     entropy_bottleneck=EntropyBottleneck(N), h_a=h_a, h_s=h_s

--- a/compressai/models/sensetime.py
+++ b/compressai/models/sensetime.py
@@ -253,6 +253,7 @@ class Elic2022Official(SimpleVAECompressionModel):
             f"y{k}": sequential_channel_ramp(
                 sum(self.groups[:k]),
                 self.groups[k] * 2,
+                min_ch=N,
                 num_layers=3,
                 make_layer=nn.Conv2d,
                 make_act=lambda: nn.ReLU(inplace=True),
@@ -281,6 +282,7 @@ class Elic2022Official(SimpleVAECompressionModel):
                 # Input: spatial context, channel context, and hyper params.
                 self.groups[k] * 2 + (k > 0) * self.groups[k] * 2 + N * 2,
                 self.groups[k] * 2,
+                min_ch=N * 2,
                 num_layers=3,
                 make_layer=nn.Conv2d,
                 make_act=lambda: nn.ReLU(inplace=True),

--- a/compressai/models/sensetime.py
+++ b/compressai/models/sensetime.py
@@ -482,7 +482,9 @@ class Elic2022Chandelier(SimpleVAECompressionModel):
         scctx_latent_codec = {
             f"y{k}": CheckerboardLatentCodec(
                 latent_codec={
-                    "y": GaussianConditionalLatentCodec(quantizer="ste"),
+                    "y": GaussianConditionalLatentCodec(
+                        quantizer="ste", chunks=("means", "scales")
+                    ),
                 },
                 context_prediction=spatial_context[k],
                 entropy_parameters=param_aggregation[k],

--- a/compressai/models/sensetime.py
+++ b/compressai/models/sensetime.py
@@ -29,9 +29,9 @@
 
 import torch.nn as nn
 
-from compressai.entropy_models import EntropyBottleneck, GaussianConditional
 from compressai.latent_codecs import (
     CheckerboardLatentCodec,
+    GaussianConditionalLatentCodec,
     HyperLatentCodec,
     HyperpriorLatentCodec,
 )
@@ -126,7 +126,9 @@ class Cheng2020AnchorCheckerboard(SimpleVAECompressionModel):
             N,
             latent_codec={
                 "y": CheckerboardLatentCodec(
-                    gaussian_conditional=GaussianConditional(None),
+                    latent_codec={
+                        "y": GaussianConditionalLatentCodec(quantizer="ste"),
+                    },
                     entropy_parameters=nn.Sequential(
                         nn.Conv2d(N * 12 // 3, N * 10 // 3, 1),
                         nn.LeakyReLU(inplace=True),
@@ -138,12 +140,7 @@ class Cheng2020AnchorCheckerboard(SimpleVAECompressionModel):
                         N, 2 * N, kernel_size=5, padding=2, stride=1
                     ),
                 ),
-                "hyper": HyperLatentCodec(
-                    N,
-                    h_a=h_a,
-                    h_s=h_s,
-                    entropy_bottleneck=EntropyBottleneck(N),
-                ),
+                "hyper": HyperLatentCodec(N, h_a=h_a, h_s=h_s),
             },
         )
 

--- a/compressai/models/sensetime.py
+++ b/compressai/models/sensetime.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2021-2022, InterDigital Communications, Inc
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted (subject to the limitations in the disclaimer
+# below) provided that the following conditions are met:
+
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of InterDigital Communications, Inc nor the names of its
+#   contributors may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+
+# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+# THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+# NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import torch.nn as nn
+
+from compressai.entropy_models import EntropyBottleneck, GaussianConditional
+from compressai.latent_codecs import (
+    CheckerboardLatentCodec,
+    HyperLatentCodec,
+    HyperpriorLatentCodec,
+)
+from compressai.layers import (
+    ResidualBlock,
+    ResidualBlockUpsample,
+    ResidualBlockWithStride,
+    conv3x3,
+    subpel_conv3x3,
+)
+from compressai.layers.layers import CheckerboardMaskedConv2d
+from compressai.registry import register_model
+
+from .base import SimpleVAECompressionModel
+
+__all__ = [
+    "Cheng2020AnchorCheckerboard",
+]
+
+
+@register_model("cheng2020-anchor-checkerboard")
+class Cheng2020AnchorCheckerboard(SimpleVAECompressionModel):
+    """Cheng2020 anchor model with checkerboard context model.
+
+    Base transform model from [Cheng2020]. Context model from [He2021].
+
+    [Cheng2020]: `"Learned Image Compression with Discretized Gaussian
+    Mixture Likelihoods and Attention Modules"
+    <https://arxiv.org/abs/2001.01568>`_, by Zhengxue Cheng, Heming Sun,
+    Masaru Takeuchi, and Jiro Katto, CVPR 2020.
+
+    [He2021]: `"Checkerboard Context Model for Efficient Learned Image
+    Compression" <https://arxiv.org/abs/2103.15306>`_, by Dailan He,
+    Yaoyan Zheng, Baocheng Sun, Yan Wang, and Hongwei Qin, CVPR 2021.
+
+    Uses residual blocks with small convolutions (3x3 and 1x1), and sub-pixel
+    convolutions for up-sampling.
+
+    Args:
+        N (int): Number of channels
+    """
+
+    def __init__(self, N=192, **kwargs):
+        super().__init__(**kwargs)
+
+        self.g_a = nn.Sequential(
+            ResidualBlockWithStride(3, N, stride=2),
+            ResidualBlock(N, N),
+            ResidualBlockWithStride(N, N, stride=2),
+            ResidualBlock(N, N),
+            ResidualBlockWithStride(N, N, stride=2),
+            ResidualBlock(N, N),
+            conv3x3(N, N, stride=2),
+        )
+
+        self.g_s = nn.Sequential(
+            ResidualBlock(N, N),
+            ResidualBlockUpsample(N, N, 2),
+            ResidualBlock(N, N),
+            ResidualBlockUpsample(N, N, 2),
+            ResidualBlock(N, N),
+            ResidualBlockUpsample(N, N, 2),
+            ResidualBlock(N, N),
+            subpel_conv3x3(N, 3, 2),
+        )
+
+        h_a = nn.Sequential(
+            conv3x3(N, N),
+            nn.LeakyReLU(inplace=True),
+            conv3x3(N, N),
+            nn.LeakyReLU(inplace=True),
+            conv3x3(N, N, stride=2),
+            nn.LeakyReLU(inplace=True),
+            conv3x3(N, N),
+            nn.LeakyReLU(inplace=True),
+            conv3x3(N, N, stride=2),
+        )
+
+        h_s = nn.Sequential(
+            conv3x3(N, N),
+            nn.LeakyReLU(inplace=True),
+            subpel_conv3x3(N, N, 2),
+            nn.LeakyReLU(inplace=True),
+            conv3x3(N, N * 3 // 2),
+            nn.LeakyReLU(inplace=True),
+            subpel_conv3x3(N * 3 // 2, N * 3 // 2, 2),
+            nn.LeakyReLU(inplace=True),
+            conv3x3(N * 3 // 2, N * 2),
+        )
+
+        self.latent_codec = HyperpriorLatentCodec(
+            N,
+            latent_codec={
+                "y": CheckerboardLatentCodec(
+                    gaussian_conditional=GaussianConditional(None),
+                    entropy_parameters=nn.Sequential(
+                        nn.Conv2d(N * 12 // 3, N * 10 // 3, 1),
+                        nn.LeakyReLU(inplace=True),
+                        nn.Conv2d(N * 10 // 3, N * 8 // 3, 1),
+                        nn.LeakyReLU(inplace=True),
+                        nn.Conv2d(N * 8 // 3, N * 6 // 3, 1),
+                    ),
+                    context_prediction=CheckerboardMaskedConv2d(
+                        N, 2 * N, kernel_size=5, padding=2, stride=1
+                    ),
+                ),
+                "hyper": HyperLatentCodec(
+                    N,
+                    h_a=h_a,
+                    h_s=h_s,
+                    entropy_bottleneck=EntropyBottleneck(N),
+                ),
+            },
+        )
+
+    @classmethod
+    def from_state_dict(cls, state_dict):
+        """Return a new model instance from `state_dict`."""
+        N = state_dict["g_a.0.conv1.weight"].size(0)
+        net = cls(N)
+        net.load_state_dict(state_dict)
+        return net

--- a/docs/source/latent_codecs.rst
+++ b/docs/source/latent_codecs.rst
@@ -31,6 +31,8 @@ CompressAI provides the following predefined :py:class:`~LatentCodec` subclasses
      - Like :py:class:`~HyperLatentCodec`, but with trainable gain vectors for ``z``.
    * - :py:class:`~GainHyperpriorLatentCodec`
      - Like :py:class:`~HyperpriorLatentCodec`, but with trainable gain vectors for ``y``.
+   * - :py:class:`~CheckerboardLatentCodec`
+     - Encodes ``y`` in two passes in checkerboard order.
 
 
 Diagrams for some of the above predefined latent codecs:
@@ -328,4 +330,9 @@ GainHyperLatentCodec
 GainHyperpriorLatentCodec
 -------------------------
 .. autoclass:: GainHyperpriorLatentCodec
+
+
+CheckerboardLatentCodec
+-----------------------
+.. autoclass:: CheckerboardLatentCodec
 

--- a/docs/source/latent_codecs.rst
+++ b/docs/source/latent_codecs.rst
@@ -31,6 +31,8 @@ CompressAI provides the following predefined :py:class:`~LatentCodec` subclasses
      - Like :py:class:`~HyperLatentCodec`, but with trainable gain vectors for ``z``.
    * - :py:class:`~GainHyperpriorLatentCodec`
      - Like :py:class:`~HyperpriorLatentCodec`, but with trainable gain vectors for ``y``.
+   * - :py:class:`~ChannelGroupsLatentCodec`
+     - Encodes ``y`` in multiple chunked groups, each group conditioned on previously encoded groups.
    * - :py:class:`~CheckerboardLatentCodec`
      - Encodes ``y`` in two passes in checkerboard order.
 
@@ -330,6 +332,11 @@ GainHyperLatentCodec
 GainHyperpriorLatentCodec
 -------------------------
 .. autoclass:: GainHyperpriorLatentCodec
+
+
+ChannelGroupsLatentCodec
+------------------------
+.. autoclass:: ChannelGroupsLatentCodec
 
 
 CheckerboardLatentCodec

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -45,6 +45,11 @@ Cheng2020Attention
 .. autoclass:: Cheng2020Attention
 
 
+Cheng2020AnchorCheckerboard
+---------------------------
+.. autoclass:: Cheng2020AnchorCheckerboard
+
+
 .. currentmodule:: compressai.models.video
 
 ScaleSpaceFlow

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -50,6 +50,11 @@ Cheng2020AnchorCheckerboard
 .. autoclass:: Cheng2020AnchorCheckerboard
 
 
+Cheng2020AnchorElic
+---------------------------
+.. autoclass:: Cheng2020AnchorElic
+
+
 .. currentmodule:: compressai.models.video
 
 ScaleSpaceFlow

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -50,9 +50,14 @@ Cheng2020AnchorCheckerboard
 .. autoclass:: Cheng2020AnchorCheckerboard
 
 
-Cheng2020AnchorElic
----------------------------
-.. autoclass:: Cheng2020AnchorElic
+Elic2022Official
+----------------
+.. autoclass:: Elic2022Official
+
+
+Elic2022Chandelier
+------------------
+.. autoclass:: Elic2022Chandelier
 
 
 .. currentmodule:: compressai.models.video


### PR DESCRIPTION
Checkerboard and ELIC models.

Differences from original paper:

 - The number of channels weren't specified for everything, so I made some educated guesses.
 - Trained on Vimeo90K dataset. (Not ImageNet 8000, like in official paper.)
 - GMM $K=1$, rather than GMM $K=3$, though with #239 , that may be possible too. I will update `GaussianConditionalLatentCodec` once that PR is accepted. I guess the STE " - means" offset might need some tweaking too once there's more than one mean...

---

### Checklist:

 - [ ] Train models.
   - [ ] cheng2020-anchor-checkerboard:
     - LBR_lite: `++model.name="cheng2020-anchor-checkerboard" ++hp.N=128 ++hp.M=192`
     - LBR: `++model.name="cheng2020-anchor-checkerboard" ++hp.N=192 ++hp.M=320`
     - HBR: `++model.name="cheng2020-anchor-checkerboard" ++hp.N=192 ++hp.M=320`
   - [ ] elic2022-official:
     - LBR_lite: `++model.name="elic2022-official" ++hp.N=128 ++hp.M=192 ++hp.groups='[16, 16, 32, 64, 64]'`
     - LBR: `++model.name="elic2022-official" ++hp.N=192 ++hp.M=320 ++hp.groups='[16, 16, 32, 64, 192]'`
     - HBR: `++model.name="elic2022-official" ++hp.N=192 ++hp.M=320 ++hp.groups='[16, 16, 32, 64, 192]'`
   - [ ] elic2022-chandelier:
     - LBR_lite: `++model.name="elic2022-chandelier" ++hp.N=128 ++hp.M=192 ++hp.groups='[16, 16, 32, 64, 64]'`
     - LBR: `++model.name="elic2022-chandelier" ++hp.N=192 ++hp.M=320 ++hp.groups='[16, 16, 32, 64, 192]'`
     - HBR: `++model.name="elic2022-chandelier" ++hp.N=192 ++hp.M=320 ++hp.groups='[16, 16, 32, 64, 192]'`
 - [ ] Add models to zoo.
 - [ ] Add `results/image/*/compressai-*.json`.
 - [x] Verify compatibility with Chandelier ELiC-ReImplemetation pretrained models (see below).

---

### Compatibility check with Chandelier ELiC-ReImplemetation pretrained models

Download models from:
https://github.com/VincentChandelier/ELiC-ReImplemetation#available-checkpoint

Save the following python script:

<details>

<summary>Click for python script</summary>

```python
import argparse

import torch

FORWARD_MAPPING = {
    "g_a": "g_a",
    "g_s": "g_s",
    "h_a": "latent_codec.hyper.h_a",
    "h_s": "latent_codec.hyper.h_s",
    "entropy_bottleneck": "latent_codec.hyper.entropy_bottleneck",
    "cc_transforms.0": "latent_codec.y.channel_context.y1",
    "cc_transforms.1": "latent_codec.y.channel_context.y2",
    "cc_transforms.2": "latent_codec.y.channel_context.y3",
    "cc_transforms.3": "latent_codec.y.channel_context.y4",
    "context_prediction.0": "latent_codec.y.latent_codec.y0.context_prediction",
    "context_prediction.1": "latent_codec.y.latent_codec.y1.context_prediction",
    "context_prediction.2": "latent_codec.y.latent_codec.y2.context_prediction",
    "context_prediction.3": "latent_codec.y.latent_codec.y3.context_prediction",
    "context_prediction.4": "latent_codec.y.latent_codec.y4.context_prediction",
    "ParamAggregation.0": "latent_codec.y.latent_codec.y0.entropy_parameters",
    "ParamAggregation.1": "latent_codec.y.latent_codec.y1.entropy_parameters",
    "ParamAggregation.2": "latent_codec.y.latent_codec.y2.entropy_parameters",
    "ParamAggregation.3": "latent_codec.y.latent_codec.y3.entropy_parameters",
    "ParamAggregation.4": "latent_codec.y.latent_codec.y4.entropy_parameters",
}

REVERSE_MAPPING = {
    "latent_codec.y.latent_codec.y0.y.gaussian_conditional": "gaussian_conditional",
    "latent_codec.y.latent_codec.y1.y.gaussian_conditional": "gaussian_conditional",
    "latent_codec.y.latent_codec.y2.y.gaussian_conditional": "gaussian_conditional",
    "latent_codec.y.latent_codec.y3.y.gaussian_conditional": "gaussian_conditional",
    "latent_codec.y.latent_codec.y4.y.gaussian_conditional": "gaussian_conditional",
}


def _rename_key(key):
    found = False
    for src_prefix, dst_prefix in FORWARD_MAPPING.items():
        if key.startswith(src_prefix):
            new_key = f"{dst_prefix}{key[len(src_prefix):]}"
            yield new_key
            found = True
    for dst_prefix, src_prefix in REVERSE_MAPPING.items():
        if key.startswith(src_prefix):
            new_key = f"{dst_prefix}{key[len(src_prefix):]}"
            yield new_key
            found = True
    if found:
        return
    raise RuntimeError(f"Unmapped key: {key}")


def rename_keys(state_dict):
    max_len = max(len(key) for key in state_dict.keys())
    new_state_dict = {}
    for key, value in state_dict.items():
        for new_key in _rename_key(key):
            print(f"{key:<{max_len}} -> {new_key:<{max_len}}")
            new_state_dict[new_key] = value
    return new_state_dict


def build_parser():
    parser = argparse.ArgumentParser()
    parser.add_argument(
        "--input", type=str, required=True, help="Path to the weights file"
    )
    parser.add_argument(
        "--output", type=str, required=True, help="Path to the output file"
    )
    return parser


def main():
    parser = build_parser()
    args = parser.parse_args()
    state_dict = torch.load(args.input)
    state_dict = rename_keys(state_dict)
    torch.save(state_dict, args.output)


if __name__ == "__main__":
    main()
```

</details>

Then, run:
```bash
python rename_weights_elic.py --input=ELIC_0004_ft_3980_Plateau.pth.tar --output=ELIC_0004_ft_3980_Plateau_renamed.pth.tar
python rename_weights_elic.py --input=ELIC_0008_ft_3980_Plateau.pth.tar --output=ELIC_0008_ft_3980_Plateau_renamed.pth.tar
python rename_weights_elic.py --input=ELIC_0016_ft_3980_Plateau.pth.tar --output=ELIC_0016_ft_3980_Plateau_renamed.pth.tar
python rename_weights_elic.py --input=ELIC_0032_ft_3980_Plateau.pth.tar --output=ELIC_0032_ft_3980_Plateau_renamed.pth.tar
python rename_weights_elic.py --input=ELIC_0150_ft_3980_Plateau.pth.tar --output=ELIC_0150_ft_3980_Plateau_renamed.pth.tar
python rename_weights_elic.py --input=ELIC_0450_ft_3980_Plateau.pth.tar --output=ELIC_0450_ft_3980_Plateau_renamed.pth.tar
```

Then [load the model checkpoint](https://interdigitalinc.github.io/CompressAI-Trainer/tutorials/full.html#resuming-training) in CompressAI Trainer:

```bash
compressai-train ++model.name="elic2022-chandelier" ++hp.N=192 ++hp.M=320 ++hp.groups='[16,16,32,64,192]' ++criterion.lmbda=0.004 ++paths.model_checkpoint="ELIC_0004_ft_3980_Plateau_renamed.pth.tar"
```

<sup>Or [`compressai-eval`](https://interdigitalinc.github.io/CompressAI-Trainer/tools/eval_model.html#evaluate-a-model), I guess, though I admittedly haven't used  it more than once since writing it... The [`++model.source`](https://interdigitalinc.github.io/CompressAI-Trainer/compressai_trainer/run.html#compressai_trainer.run.eval_model.load_model) thing may need some reworking/redocumenting to make it more friendly. Also, it doesn't work with non-image compression models...</sup>