### PR TITLE
fix: restore deprecated CompressionModel(entropy_bottleneck_channels)

### DIFF
--- a/compressai/models/base.py
+++ b/compressai/models/base.py
@@ -28,6 +28,7 @@
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import math
+import warnings
 
 from typing import cast
 
@@ -65,6 +66,30 @@ class CompressionModel(nn.Module):
     """Base class for constructing an auto-encoder with any number of
     EntropyBottleneck or GaussianConditional modules.
     """
+
+    def __init__(self, entropy_bottleneck_channels=None, init_weights=None):
+        super().__init__()
+
+        if entropy_bottleneck_channels is not None:
+            warnings.warn(
+                "The entropy_bottleneck_channels parameter is deprecated. "
+                "Create an entropy_bottleneck in your model directly instead:\n\n"
+                "class YourModel(CompressionModel):\n"
+                "    def __init__(self):\n"
+                "        super().__init__()\n"
+                "        self.entropy_bottleneck = "
+                "EntropyBottleneck(entropy_bottleneck_channels)\n",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            self.entropy_bottleneck = EntropyBottleneck(entropy_bottleneck_channels)
+
+        if init_weights is not None:
+            warnings.warn(
+                "The init_weights parameter was removed as it was never functional.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
     def load_state_dict(self, state_dict, strict=True):
         for name, module in self.named_modules():

--- a/compressai/utils/video/bench/codecs.py
+++ b/compressai/utils/video/bench/codecs.py
@@ -52,8 +52,8 @@ def run_command(cmd, ignore_returncodes=None):
 
 
 class Codec(abc.ABC):
-    # name = ""
-    description = ""
+    name: str
+    description: str
     help = ""
 
     @property
@@ -100,6 +100,7 @@ class x264(Codec):
     def name(self):
         return "x264"
 
+    @property
     def description(self):
         return f"{self.name} {self.preset}, {self.tune}, ffmpeg version {get_ffmpeg_version()}"
 
@@ -212,6 +213,7 @@ class VTM(Codec):
     def name(self):
         return "VTM"
 
+    @property
     def description(self):
         return f"VTM reference software, version {self.get_version(self.encoder_path)}"
 
@@ -330,6 +332,7 @@ class HM(VTM):
     def name(self):
         return "HM"
 
+    @property
     def description(self):
         return f"HM reference software, version {self.get_version(self.encoder_path)}"
 


### PR DESCRIPTION
Some external projects that use CompressAI as an importable library may depend on `CompressionModel` to create the `entropy_bottleneck`. Thus, we restore this legacy behavior (but discourage its use via a warning).

```
DeprecationWarning: The entropy_bottleneck_channels parameter is deprecated. Create an entropy_bottleneck in your model directly instead:

class YourModel(CompressionModel):
    def __init__(self):
        super().__init__()
        self.entropy_bottleneck = EntropyBottleneck(entropy_bottleneck_channels)
```

---

Also fixes broken CI in https://github.com/InterDigitalInc/CompressAI/pull/248/commits/f90b6cb215e34c91c081b1ed5c13d9491df8c74d.