### PR TITLE
feat: SpectralConv2d, SpectralConvTranspose2d

### DIFF
--- a/compressai/layers/layers.py
+++ b/compressai/layers/layers.py
@@ -27,7 +27,7 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import Any
+from typing import Any, Tuple
 
 import torch
 import torch.nn as nn
@@ -43,10 +43,71 @@ __all__ = [
     "ResidualBlock",
     "ResidualBlockUpsample",
     "ResidualBlockWithStride",
+    "SpectralConv2d",
+    "SpectralConvTranspose2d",
     "conv3x3",
     "subpel_conv3x3",
     "QReLU",
 ]
+
+
+class _SpectralConvNdMixin:
+    def __init__(self, dim: Tuple[int, ...]):
+        self.dim = dim
+        self.weight_transformed = nn.Parameter(self._to_transform_domain(self.weight))
+        del self._parameters["weight"]  # Unregister weight, and fallback to property.
+
+    @property
+    def weight(self) -> Tensor:
+        return self._from_transform_domain(self.weight_transformed)
+
+    def _to_transform_domain(self, x: Tensor) -> Tensor:
+        return torch.fft.rfftn(x, s=self.kernel_size, dim=self.dim, norm="ortho")
+
+    def _from_transform_domain(self, x: Tensor) -> Tensor:
+        return torch.fft.irfftn(x, s=self.kernel_size, dim=self.dim, norm="ortho")
+
+
+class SpectralConv2d(nn.Conv2d, _SpectralConvNdMixin):
+    r"""Spectral 2D convolution.
+
+    Introduced in [Balle2018efficient].
+    Reparameterizes the weights to be derived from weights stored in the
+    frequency domain.
+    In the original paper, this is referred to as "spectral Adam" or
+    "Sadam" due to its effect on the Adam optimizer update rule.
+    The motivation behind representing the weights in the frequency
+    domain is that optimizer updates/steps may now affect all
+    frequencies to an equal amount.
+    This improves the gradient conditioning, thus leading to faster
+    convergence and increased stability at larger learning rates.
+
+    For comparison, see the TensorFlow Compression implementations of
+    `SignalConv2D
+    <https://github.com/tensorflow/compression/blob/v2.14.0/tensorflow_compression/python/layers/signal_conv.py#L61>`_
+    and
+    `RDFTParameter
+    <https://github.com/tensorflow/compression/blob/v2.14.0/tensorflow_compression/python/layers/parameters.py#L71>`_.
+
+    [Balle2018efficient]: `"Efficient Nonlinear Transforms for Lossy
+    Image Compression" <https://arxiv.org/abs/1802.00847>`_,
+    by Johannes Ballé, PCS 2018.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        _SpectralConvNdMixin.__init__(self, dim=(-2, -1))
+
+
+class SpectralConvTranspose2d(nn.ConvTranspose2d, _SpectralConvNdMixin):
+    r"""Spectral 2D transposed convolution.
+
+    Transposed version of :class:`SpectralConv2d`.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        _SpectralConvNdMixin.__init__(self, dim=(-2, -1))
 
 
 class MaskedConv2d(nn.Conv2d):


### PR DESCRIPTION
Introduced in ["Efficient Nonlinear Transforms for Lossy Image Compression"][Balle2018efficient] by Johannes Ballé, PCS 2018. Reparameterizes the weights to be derived from weights stored in the frequency domain. In the original paper, this is referred to as "spectral Adam" or "Sadam" due to its effect on the Adam optimizer update rule. The motivation behind representing the weights in the frequency domain is that optimizer updates/steps may now affect all frequencies to an equal amount. This improves the gradient conditioning, thus leading to faster convergence and increased stability at larger learning rates.

![spectral_adam](https://github.com/InterDigitalInc/CompressAI/assets/721196/f065210f-dfec-4b89-9ded-b1ded4516cea)

![spectral_adam_rd_curves](https://github.com/InterDigitalInc/CompressAI/assets/721196/32cc96c0-094c-45d3-86e2-7d168fdea83f)

For comparison, see the TensorFlow Compression implementations of [`SignalConv2D`] and [`RDFTParameter`]. They seem to use `SignalConv2d` in most of their provided architectures:
https://github.com/search?q=repo%3Atensorflow%2Fcompression+Conv2D&type=code

Furthermore, since this is a simple invertible transformation on the weights, it is trivial to convert any existing pretrained weights into this form via:

```python
weight_transformed = self._to_transform_domain(weight)
```

To override `self.weight` as a property, I'm unregistering the module using `del self._parameters["weight"]` as shown in https://github.com/pytorch/pytorch/issues/46886, and also [using the fact][property-descriptor-so] that `@property` [returns a descriptor object][property-descriptor-docs] so that `self.weight` "falls back" to the property.

```python
    def __init__(self, ...):
        self.weight_transformed = nn.Parameter(self._to_transform_domain(self.weight))
        del self._parameters["weight"]  # Unregister weight, and fallback to property.

    @property
    def weight(self) -> Tensor:
        return self._from_transform_domain(self.weight_transformed)
```

---

Checklist:

 - [ ] Verify: See if training from scratch actually improves performance or training times by appropriately replacing conv/deconv in existing models.
 - [ ] Verify: Check that `SpectralConvTransposed2d` is defined correctly... Since `nn.ConvTransposed2d` inherits from the same `_ConvNd` as `nn.Conv2d` with minor adjustments, I assumed that the weights are treated in the same way.
 - [ ] Ergonomics: If we choose to offer reparametrized versions of already created models, they should override `load_state_dict` to be able to load/write checkpoints in a way that is compatible with the original (non-reparametrized) model definitions.
 - [ ] Performance (medium): See if PyTorch 2.0 Dynamo's [model compilation](https://pytorch.org/tutorials/intermediate/torch_compile_tutorial.html) works when we manually use 2x `torch.float32` instead of `torch.complex64`. Or maybe it's just the FFT which ruins things. It would be nice if there were a way to skip compilation for certain incompatible operations, particularly since we're merely taking a FFT of leaf tensors, not intermediate computations...
 - [ ] Performance (minor): During inference time, the convolution weights can be precomputed, instead of having to run a FFT on them repeatedly. Perhaps this can be handled inside `CompressionModel.update()`. Or even easier: when the `SpectralConv2d` module is in [`eval` mode], just cache the computed weight, and invalidate/clear the cache when the module switches back to `train` mode.
 - [x] Naming: There's not too many collisions with existing usages of [`SpectralConv2d` on Google](https://www.google.com/search?q=SpectralConv2d), so this should be an OK name. Tensorflow Compression calls their conv layers `SignalConv2d`. Perhaps the most "accurate" name would be `SpectralReparametrizedConv2d`, but that's a bit wordy.


[Balle2018efficient]: https://arxiv.org/abs/1802.00847
[`SignalConv2D`]: https://github.com/tensorflow/compression/blob/v2.14.0/tensorflow_compression/python/layers/signal_conv.py#L61
[`RDFTParameter`]: https://github.com/tensorflow/compression/blob/v2.14.0/tensorflow_compression/python/layers/parameters.py#L71
[property-descriptor-docs]: https://docs.python.org/3/howto/descriptor.html#properties
[property-descriptor-so]: https://stackoverflow.com/a/17330273/365102
[`eval` mode]: https://stackoverflow.com/a/51433411/365102