### PR TITLE
Video datasets: Pregenerated, and Vimeo90K 

### DIFF
--- a/compressai/datasets/vimeo90k.py
+++ b/compressai/datasets/vimeo90k.py
@@ -64,6 +64,9 @@ class Vimeo90kDataset(Dataset):
         tuplet (int): order of dataset tuplet (e.g. 3 for "triplet" dataset)
     """
 
+    TUPLET_PREFIX = {3: "tri", 7: "sep"}
+    SPLIT_TO_LIST_SUFFIX = {"train": "trainlist", "valid": "testlist"}
+
     def __init__(self, root, transform=None, split="train", tuplet=3):
         list_path = Path(root) / self._list_filename(split, tuplet)
 
@@ -94,6 +97,6 @@ class Vimeo90kDataset(Dataset):
         return len(self.samples)
 
     def _list_filename(self, split: str, tuplet: int) -> str:
-        tuplet_prefix = {3: "tri", 7: "sep"}[tuplet]
-        list_suffix = {"train": "trainlist", "valid": "testlist"}[split]
+        tuplet_prefix = self.TUPLET_PREFIX[tuplet]
+        list_suffix = self.SPLIT_TO_LIST_SUFFIX[split]
         return f"{tuplet_prefix}_{list_suffix}.txt"


### PR DESCRIPTION
Added `mode="video"` parameter to `PreGeneratedMemmapDataset` and `Vimeo90kDataset`.

To generate the pregenerated numpy datasets:

```bash
cd /data/datasets

mkdir -p vimeo90k
cd vimeo90k
wget http://data.csail.mit.edu/tofu/dataset/vimeo_triplet.zip
unzip vimeo_triplet.zip
wget http://data.csail.mit.edu/tofu/dataset/vimeo_septuplet.zip
unzip vimeo_septuplet.zip
cd ..

wget https://gist.githubusercontent.com/YodaEmbedding/8803d95de072f12b4ff14ffd2b5bd7e5/raw/9db2d7664984cc29b790f6b5268b971ec004c50c/generate_vimeo90k_npy_dataset.py

# NOTE: Ignore the first one if it already exists:
python generate_vimeo90k_npy_dataset.py --tuplet=3 --mode=image --indir="vimeo90k/vimeo_triplet" --outdir="vimeo90k/vimeo_triplet_npy"

python generate_vimeo90k_npy_dataset.py --tuplet=3 --mode=video --indir="vimeo90k/vimeo_triplet" --outdir="vimeo90k/vimeo_triplet_npy_video"

python generate_vimeo90k_npy_dataset.py --tuplet=7 --mode=image --indir="vimeo90k/vimeo_septuplet" --outdir="vimeo90k/vimeo_septuplet_npy"

python generate_vimeo90k_npy_dataset.py --tuplet=7 --mode=video --indir="vimeo90k/vimeo_septuplet" --outdir="vimeo90k/vimeo_septuplet_npy_video"
```

---

Example config (works only on latest CompressAI Trainer dev branch):

```yaml
type: "PreGeneratedMemmapDataset"
config:
  root: "${paths.datasets}/vimeo90k/vimeo_septuplet_npy_video"
  split: "train"
  image_size: [ 256, 256, ]
  mode: "video"
  frames_per_sample: 7
loader:
  shuffle: True
  batch_size: 16
  num_workers: 2
settings:
  patch_size: [ 256, 256, ]
transforms:
  transform_frame:
    - "ToTensor": {}
  transform:
    - "RandomCrop": {size: "${.....settings.patch_size}"}
meta:
  name: "Vimeo-90K"
  identifier:
  num_samples: 64612
  steps_per_epoch:
```