### PR TITLE
Store `nn.Parameter` in `entropy_models.py` in `nn.ParameterList`

### DIFF
--- a/compressai/entropy_models/entropy_models.py
+++ b/compressai/entropy_models/entropy_models.py
@@ -29,7 +29,7 @@
 
 import warnings
 
-from typing import Any, Callable, List, Mapping, Optional, Tuple, Union
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 import numpy as np
 import scipy.stats

--- a/compressai/entropy_models/entropy_models.py
+++ b/compressai/entropy_models/entropy_models.py
@@ -483,7 +483,7 @@ class EntropyBottleneck(EntropyModel):
             # TorchScript in 2D for static inference
             # Convert to (channels, ... , batch) format
             # perm = (1, 2, 3, 0)
-            # inv_perm = (3, 0, 1, 2):
+            # inv_perm = (3, 0, 1, 2)
 
         x = x.permute(*perm).contiguous()
         shape = x.size()

--- a/compressai/models/base.py
+++ b/compressai/models/base.py
@@ -39,7 +39,7 @@ from torch import Tensor
 
 from compressai.entropy_models import EntropyBottleneck, GaussianConditional
 from compressai.latent_codecs import LatentCodec
-from compressai.models.utils import update_registered_buffers, remap_old_keys
+from compressai.models.utils import remap_old_keys, update_registered_buffers
 
 __all__ = [
     "CompressionModel",

--- a/compressai/models/base.py
+++ b/compressai/models/base.py
@@ -39,7 +39,7 @@ from torch import Tensor
 
 from compressai.entropy_models import EntropyBottleneck, GaussianConditional
 from compressai.latent_codecs import LatentCodec
-from compressai.models.utils import update_registered_buffers
+from compressai.models.utils import update_registered_buffers, remap_old_keys
 
 __all__ = [
     "CompressionModel",
@@ -103,6 +103,7 @@ class CompressionModel(nn.Module):
                     ["_quantized_cdf", "_offset", "_cdf_length"],
                     state_dict,
                 )
+                state_dict = remap_old_keys(name, state_dict)
 
             if isinstance(module, GaussianConditional):
                 update_registered_buffers(

--- a/tests/test_entropy_models.py
+++ b/tests/test_entropy_models.py
@@ -32,6 +32,8 @@ import copy
 import pytest
 import torch
 
+from packaging import version
+
 from compressai.entropy_models import (
     EntropyBottleneck,
     EntropyModel,
@@ -242,6 +244,10 @@ class TestEntropyBottleneck:
     #     assert torch.allclose(y0[0], y1[0])
     #     assert torch.all(y1[1] == 0)  # not yet supported
 
+    @pytest.mark.skipif(
+        version.parse(torch.__version__) < version.parse("2.0.0"),
+        reason="torch.compile only available for torch>=2.0",
+    )
     def test_compiling(self):
         entropy_bottleneck = EntropyBottleneck(128)
         x0 = torch.rand(1, 128, 32, 32)


### PR DESCRIPTION
This PR proposes to store parameters in `entropy_models.py` in an `nn.ParameterList` instead of its current string-based lookup. The primary reason to do so is to make `EntropyBottleneck` more friendly for `torch.compile`, where the current implementation fails to compile for certain backends (in my own experience, dynamo). The primary reason seems to be that the current implementation relies too much on Python strings and class attributes to access the parameters, whereas the new implementation makes this more clear at the PyTorch level, which helps the compiler.

A major drawback to the PR merging would be that it breaks backwards compatibility. I've included some state_dict adjustments that would allow loading old checkpoints, but I understand this may not be ideal. Also, new checkpoints would not be loadable by older versions of `compressai`.

The PR also includes a compile test for verifying the implementation.

Happy to see this merged or closed, depending on maintainer preference.