### PR TITLE
refactor: remove redundant Tensor allocation in GaussianConditional.update()

### DIFF
--- a/compressai/entropy_models/entropy_models.py
+++ b/compressai/entropy_models/entropy_models.py
@@ -677,7 +677,6 @@ class GaussianConditional(EntropyModel):
 
         tail_mass = 2 * lower[:, :1]
 
-        quantized_cdf = torch.Tensor(len(pmf_length), max_length + 2)
         quantized_cdf = self._pmf_to_cdf(pmf, tail_mass, pmf_length, max_length)
         self._quantized_cdf = quantized_cdf
         self._offset = -pmf_center


### PR DESCRIPTION
## Suggestion
This PR removes a redundant one-line Tensor allocation in
`GaussianConditional.update()` within `entropy_models.py`.

```python
# Before
quantized_cdf = torch.Tensor(len(pmf_length), max_length + 2)
quantized_cdf = self._pmf_to_cdf(pmf, tail_mass, pmf_length, max_length)

# After
quantized_cdf = self._pmf_to_cdf(pmf, tail_mass, pmf_length, max_length)
```

## Testing
- Ran unit tests that exercise GaussianConditional.update() and dependent
compression/decompression paths; no regressions observed.

- Verified that self._quantized_cdf, self._offset, and self._cdf_length
match previous values bit-for-bit for a fixed scale_table.

## Why this trivial change matters 
TorchDynamo or FX tracing can sometimes interpret redundant allocations as live ops, bloating the captured graph.

Removing this line avoids all of the above while keeping `_pmf_to_cdf()` solely responsible for dtype and device consistency.

No behavioral change is expected; this is a safe cleanup.