### PR TITLE
refactor: add backward compatibility with legacy hyperprior state dict

### DIFF
--- a/compressai/models/base.py
+++ b/compressai/models/base.py
@@ -38,8 +38,16 @@ import torch.nn as nn
 from torch import Tensor
 
 from compressai.entropy_models import EntropyBottleneck, GaussianConditional
-from compressai.latent_codecs import LatentCodec
-from compressai.models.utils import remap_old_keys, update_registered_buffers
+from compressai.latent_codecs import (
+    GainHyperpriorLatentCodec,
+    HyperpriorLatentCodec,
+    LatentCodec,
+)
+from compressai.models.utils import (
+    remap_legacy_hyperprior_keys,
+    remap_old_keys,
+    update_registered_buffers,
+)
 
 __all__ = [
     "CompressionModel",
@@ -95,6 +103,9 @@ class CompressionModel(nn.Module):
         for name, module in self.named_modules():
             if not any(x.startswith(name) for x in state_dict.keys()):
                 continue
+
+            if isinstance(module, (HyperpriorLatentCodec, GainHyperpriorLatentCodec)):
+                state_dict = remap_legacy_hyperprior_keys(name, state_dict)
 
             if isinstance(module, EntropyBottleneck):
                 update_registered_buffers(

--- a/compressai/models/utils.py
+++ b/compressai/models/utils.py
@@ -147,6 +147,27 @@ def remap_old_keys(module_name, state_dict):
     return new_state_dict
 
 
+def remap_legacy_hyperprior_keys(module_name, state_dict):
+    old_prefix = f"{module_name}.hyper."
+    new_state_dict = OrderedDict()
+
+    for k, v in state_dict.items():
+        if k.startswith(f"{old_prefix}h_a."):
+            k = k.replace(f"{old_prefix}h_a.", f"{module_name}.h_a.", 1)
+        elif k.startswith(f"{old_prefix}h_s."):
+            k = k.replace(f"{old_prefix}h_s.", f"{module_name}.h_s.", 1)
+        elif k.startswith(f"{old_prefix}entropy_bottleneck."):
+            k = k.replace(
+                f"{old_prefix}entropy_bottleneck.",
+                f"{module_name}.z.entropy_bottleneck.",
+                1,
+            )
+
+        new_state_dict[k] = v
+
+    return new_state_dict
+
+
 def conv(in_channels, out_channels, kernel_size=5, stride=2):
     return nn.Conv2d(
         in_channels,


### PR DESCRIPTION
## Summary

This PR restores backward compatibility when loading legacy checkpoints for models using `HyperpriorLatentCodec`.

## Problem

Older checkpoints use the nested hyperprior layout:

- `latent_codec.hyper.h_a.*`
- `latent_codec.hyper.h_s.*`
- `latent_codec.hyper.entropy_bottleneck.*`

Current checkpoints use the refactored layout:

- `latent_codec.h_a.*`
- `latent_codec.h_s.*`
- `latent_codec.z.entropy_bottleneck.*`

`CompressionModel.load_state_dict()` already handles some legacy `EntropyBottleneck` key conversions, but it did not handle this module-path migration. As a result, loading old checkpoints in the current code raises strict key mismatches.

## What Changed

This PR keeps the fix minimal and limited to checkpoint loading:

- add a legacy hyperprior key remap helper in `compressai/models/utils.py`
- apply that remap from `CompressionModel.load_state_dict()` in `compressai/models/base.py`
- keep the existing buffer update and legacy `EntropyBottleneck` remap logic unchanged

The remap is:

- `...hyper.h_a.* -> ...h_a.*`
- `...hyper.h_s.* -> ...h_s.*`
- `...hyper.entropy_bottleneck.* -> ...z.entropy_bottleneck.*`

## Affected Models

Confirmed in this repository:

- `cheng2020-anchor-checkerboard`
- `elic2022-official`
- `elic2022-chandelier`

## Validation

Using checkpoints exported from commit `6cc371fde518e61bb9953a00a1dbec1b858e899f`, I verified that the patched current code loads them successfully for:

- `cheng2020-anchor-checkerboard`
- `elic2022-official`
- `elic2022-chandelier`

and that the resulting current-format `state_dict` matches the expected remapped tensors exactly.

Verification result:

```json
{
  "cheng2020-anchor-checkerboard": {
    "loaded": true,
    "num_keys": 160,
    "mismatches": 0
  },
  "elic-official": {
    "loaded": true,
    "num_keys": 412,
    "mismatches": 0
  },
  "elic-chandelier": {
    "loaded": true,
    "num_keys": 412,
    "mismatches": 0
  }
}
```

## Scope
This change only restores backward compatibility for loading legacy checkpoints into the current code.

Thanks for your time reviewing this PR.